### PR TITLE
Add org scope to API keys

### DIFF
--- a/pkg/api/property_test.go
+++ b/pkg/api/property_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -741,6 +742,44 @@ func TestApiGetPropertyPermissions(t *testing.T) {
 	}
 }
 
+func TestApiGetPropertyAPIKeyOrgScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := common.TraceContext(t.Context(), t.Name())
+
+	user, org, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, false /*read-only*/, true /*org scope*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org2, _, err := store.Impl().CreateNewOrganization(ctx, t.Name()+"-another-org", user.ID)
+	if err != nil {
+		t.Fatalf("Failed to create extra org: %v", err)
+	}
+
+	property, _, err := s.BusinessDB.Impl().CreateNewProperty(ctx, db_test.CreateNewPropertyParams(user.ID, "example.com"), org2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	propertyID := s.IDHasher.Encrypt(int(property.ID))
+
+	resp, err := apiRequestSuite(ctx, nil,
+		http.MethodGet,
+		fmt.Sprintf("/%s/%s/%s/%s", common.OrgEndpoint, s.IDHasher.Encrypt(int(org.ID)),
+			common.PropertyEndpoint, propertyID),
+		apiKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Unexpected status code: %v", resp.StatusCode)
+	}
+}
+
 func TestApiPostPropertiesInvalidKey(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -793,7 +832,7 @@ func TestApiPostPropertiesReadOnlyKey(t *testing.T) {
 		},
 	}
 
-	_, org, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/)
+	_, org, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/, false /*scope org*/)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -841,7 +880,7 @@ func TestApiDeletePropertiesReadOnlyKey(t *testing.T) {
 
 	ctx := common.TraceContext(t.Context(), t.Name())
 
-	user, org, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/)
+	user, org, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/, false /*scope org*/)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -905,7 +944,7 @@ func TestApiUpdatePropertiesReadOnlyKey(t *testing.T) {
 
 	ctx := common.TraceContext(t.Context(), t.Name())
 
-	user, org, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/)
+	user, org, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/, false /*scope org*/)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -984,5 +1023,224 @@ func TestApiGetPropertyInvalidKey(t *testing.T) {
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("Unexpected status code: %v", resp.StatusCode)
+	}
+}
+
+func TestApiGetPropertiesAPIKeyOrgScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := t.Context()
+	user, _, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, false /*read-only*/, true /*org scope*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org2, _, err := store.Impl().CreateNewOrganization(ctx, t.Name()+"-another-org", user.ID)
+	if err != nil {
+		t.Fatalf("Failed to create extra org: %v", err)
+	}
+
+	endpoint := fmt.Sprintf("/%s/%v/%s", common.OrgEndpoint, s.IDHasher.Encrypt(int(org2.ID)), common.PropertiesEndpoint)
+	resp, err := apiRequestSuite(ctx, nil, http.MethodGet, endpoint, apiKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Unexpected status code: %v", resp.StatusCode)
+	}
+}
+
+func TestApiPostPropertiesAPIKeyOrgScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := common.TraceContext(t.Context(), t.Name())
+
+	user, _, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, false /*read-only*/, true /*org scope*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org2, _, err := store.Impl().CreateNewOrganization(ctx, t.Name()+"-another-org", user.ID)
+	if err != nil {
+		t.Fatalf("Failed to create extra org: %v", err)
+	}
+
+	inputs := []*apiCreatePropertyInput{
+		{
+			apiPropertySettings: apiPropertySettings{
+				Name: "Property",
+			},
+			Domain: "example.com",
+		},
+	}
+
+	resp, err := apiRequestSuite(ctx, inputs,
+		http.MethodPost,
+		fmt.Sprintf("/%s/%s/%s", common.OrgEndpoint, s.IDHasher.Encrypt(int(org2.ID)), common.PropertiesEndpoint),
+		apiKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Unexpected status code: %v", resp.StatusCode)
+	}
+}
+
+func TestApiDeletePropertiesAPIKeyOrgScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := common.TraceContext(t.Context(), t.Name())
+
+	user, _, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, false /*read-only*/, true /*org scope*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org2, _, err := store.Impl().CreateNewOrganization(ctx, t.Name()+"-another-org", user.ID)
+	if err != nil {
+		t.Fatalf("Failed to create extra org: %v", err)
+	}
+
+	property, _, err := s.BusinessDB.Impl().CreateNewProperty(ctx, db_test.CreateNewPropertyParams(user.ID, "example.com"), org2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idsToDelete := []string{
+		s.IDHasher.Encrypt(int(property.ID)),
+	}
+
+	output, meta, err := requestResponseAPISuite[*apiAsyncTaskOutput](ctx, idsToDelete,
+		http.MethodDelete,
+		"/"+common.PropertiesEndpoint,
+		apiKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !meta.Code.Success() {
+		t.Fatalf("Unexpected status code: %v", meta.Description)
+	}
+
+	finished := false
+	var results []*operationResult
+	for i := 0; i < 20; i++ {
+		time.Sleep(500 * time.Millisecond)
+
+		var result *apiAsyncTaskResultOutput
+		result, meta, err = requestResponseAPISuite[*apiAsyncTaskResultOutput](ctx, nil, http.MethodGet, "/"+common.AsyncTaskEndpoint+"/"+output.ID, apiKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !meta.Code.Success() {
+			t.Fatalf("Unexpected status code: %v", meta.Description)
+		}
+
+		if result.Finished {
+			finished = true
+			b, _ := json.Marshal(result.Result)
+			json.Unmarshal(b, &results)
+			break
+		}
+	}
+
+	if !finished {
+		t.Fatal("Async task did not complete within timeout")
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Code != common.StatusFailure {
+		t.Errorf("Expected StatusFailure, got %v", results[0].Code)
+	}
+}
+
+func TestApiUpdatePropertiesAPIKeyOrgScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := common.TraceContext(t.Context(), t.Name())
+
+	user, _, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, false /*read-only*/, true /*org scope*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org2, _, err := store.Impl().CreateNewOrganization(ctx, t.Name()+"-another-org", user.ID)
+	if err != nil {
+		t.Fatalf("Failed to create extra org: %v", err)
+	}
+
+	property, _, err := s.BusinessDB.Impl().CreateNewProperty(ctx, db_test.CreateNewPropertyParams(user.ID, "example.com"), org2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updates := []*apiUpdatePropertyInput{
+		{
+			ID: s.IDHasher.Encrypt(int(property.ID)),
+			apiPropertySettings: apiPropertySettings{
+				Name: "Updated Property",
+			},
+		},
+	}
+
+	output, meta, err := requestResponseAPISuite[*apiAsyncTaskOutput](ctx, updates,
+		http.MethodPut,
+		"/"+common.PropertiesEndpoint,
+		apiKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !meta.Code.Success() {
+		t.Fatalf("Unexpected status code: %v", meta.Description)
+	}
+
+	finished := false
+	var results []*operationResult
+	for i := 0; i < 20; i++ {
+		time.Sleep(500 * time.Millisecond)
+
+		var result *apiAsyncTaskResultOutput
+		result, meta, err = requestResponseAPISuite[*apiAsyncTaskResultOutput](ctx, nil, http.MethodGet, "/"+common.AsyncTaskEndpoint+"/"+output.ID, apiKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !meta.Code.Success() {
+			t.Fatalf("Unexpected status code: %v", meta.Description)
+		}
+
+		if result.Finished {
+			finished = true
+			b, _ := json.Marshal(result.Result)
+			json.Unmarshal(b, &results)
+			break
+		}
+	}
+
+	if !finished {
+		t.Fatal("Async task did not complete within timeout")
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(results))
+	}
+
+	if results[0].Code != common.StatusOrgPermissionsError {
+		t.Errorf("Expected StatusOrgPermissionsError, got %v", results[0].Code)
 	}
 }

--- a/pkg/api/task_test.go
+++ b/pkg/api/task_test.go
@@ -82,7 +82,7 @@ func TestGetAsyncTaskReadOnlyKey(t *testing.T) {
 
 	ctx := common.TraceContext(t.Context(), t.Name())
 
-	user, _, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/)
+	user, _, apiKey, err := setupAPISuiteEx(ctx, t.Name(), dbgen.ApiKeyScopePortal, true /*read-only*/, false /*scope org*/)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/api/verifier.go
+++ b/pkg/api/verifier.go
@@ -216,9 +216,16 @@ func (v *Verifier) Verify(ctx context.Context, verifyPayload puzzle.SolutionPayl
 	if property != nil {
 		// position in code where expected owner is checked is a tradeoff between compute for verifying solutions (below)
 		// and IO for accessing DB of potentially malicious request (in case not-yet-checked API key turns out invalid)
-		if ownerID, err := expectedOwner.OwnerID(ctx, tnow); err == nil {
+		if ownerID, ownerOrgID, err := expectedOwner.OwnerID(ctx, tnow); err == nil {
 			if !v.checkUserPermissions(ctx, property, ownerID) {
 				result.SetError(puzzle.WrongOwnerError)
+				return result, nil
+			}
+
+			// for scoped API keys, we want to take org ID into account
+			if (ownerOrgID != nil) && (property.OrgID.Int32 != *ownerOrgID) {
+				slog.WarnContext(ctx, "Owner org scope does not match property org", "propertyOrgID", property.OrgID.Int32, "ownerOrgID", *ownerOrgID)
+				result.SetError(puzzle.OrgScopeError)
 				return result, nil
 			}
 		} else {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -48,6 +48,7 @@ const (
 	ParamPage             = "page"
 	ParamPerPage          = "per_page"
 	ParamScope            = "scope"
+	All                   = "all"
 )
 
 var (

--- a/pkg/db/generated/models.go
+++ b/pkg/db/generated/models.go
@@ -286,6 +286,7 @@ type APIKey struct {
 	CreatedAt         pgtype.Timestamptz `db:"created_at" json:"created_at"`
 	ExpiresAt         pgtype.Timestamptz `db:"expires_at" json:"expires_at"`
 	Notes             pgtype.Text        `db:"notes" json:"notes"`
+	OrgID             pgtype.Int4        `db:"org_id" json:"org_id"`
 	UpdatedAt         pgtype.Timestamptz `db:"updated_at" json:"updated_at"`
 	Period            time.Duration      `db:"period" json:"period"`
 	Scope             ApiKeyScope        `db:"scope" json:"scope"`

--- a/pkg/db/migrations/postgres/0000116_add_apikey_orgid_column.down.sql
+++ b/pkg/db/migrations/postgres/0000116_add_apikey_orgid_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backend.apikeys DROP COLUMN org_id;

--- a/pkg/db/migrations/postgres/0000116_add_apikey_orgid_column.up.sql
+++ b/pkg/db/migrations/postgres/0000116_add_apikey_orgid_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backend.apikeys ADD COLUMN org_id INT REFERENCES backend.organizations(id) ON DELETE CASCADE;

--- a/pkg/db/queries/postgres/apikeys.sql
+++ b/pkg/db/queries/postgres/apikeys.sql
@@ -8,7 +8,7 @@ SELECT * FROM backend.apikeys WHERE user_id = $1 AND expires_at > NOW();
 SELECT * FROM backend.apikeys WHERE user_id = $1 AND name = $2 AND expires_at > NOW();
 
 -- name: CreateAPIKey :one
-INSERT INTO backend.apikeys (name, user_id, expires_at, requests_per_second, requests_burst, period, scope, readonly) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *;
+INSERT INTO backend.apikeys (name, user_id, expires_at, requests_per_second, requests_burst, period, scope, readonly, org_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *;
 
 -- name: UpdateAPIKey :one
 UPDATE backend.apikeys SET expires_at = $1, enabled = $2, updated_at = NOW() WHERE external_id = $3 RETURNING *;

--- a/pkg/db/queries/postgres/properties.sql
+++ b/pkg/db/queries/postgres/properties.sql
@@ -15,7 +15,7 @@ RETURNING *;
 -- name: UpdateProperty :one
 WITH old AS (
     SELECT * FROM backend.properties p
-    WHERE p.id = $1 AND (p.creator_id = $9 OR p.org_owner_id = $9)
+    WHERE p.id = $1 AND (p.creator_id = $9 OR p.org_owner_id = $9) AND (p.org_id = $10 OR $10 IS NULL)
     FOR UPDATE
 ),
 upd AS (
@@ -66,7 +66,7 @@ LIMIT $3;
 UPDATE backend.properties SET deleted_at = NOW(), updated_at = NOW(), name = name || ' deleted_' || substr(md5(random()::text), 1, 8) WHERE id = $1 RETURNING *;
 
 -- name: SoftDeleteProperties :many
-UPDATE backend.properties SET deleted_at = NOW(), updated_at = NOW(), name = name || ' deleted_' || substr(md5(random()::text), 1, 8) WHERE id = ANY($1::INT[]) AND (creator_id = $2 OR org_owner_id = $2) AND deleted_at IS NULL RETURNING *;
+UPDATE backend.properties SET deleted_at = NOW(), updated_at = NOW(), name = name || ' deleted_' || substr(md5(random()::text), 1, 8) WHERE id = ANY($1::INT[]) AND (creator_id = $2 OR org_owner_id = $2) AND (org_id = $3 OR $3 IS NULL) AND deleted_at IS NULL RETURNING *;
 
 -- name: GetSoftDeletedProperties :many
 SELECT sqlc.embed(p)

--- a/pkg/db/utils.go
+++ b/pkg/db/utils.go
@@ -24,6 +24,7 @@ const (
 
 var (
 	invalidUUID = pgtype.UUID{Valid: false}
+	InvalidInt  = pgtype.Int4{Valid: false}
 )
 
 func IsInternalSubscription(source dbgen.SubscriptionSource) bool {

--- a/pkg/portal/login.go
+++ b/pkg/portal/login.go
@@ -47,14 +47,17 @@ type portalPropertyOwnerSource struct {
 
 var _ puzzle.OwnerIDSource = (*portalPropertyOwnerSource)(nil)
 
-func (s *portalPropertyOwnerSource) OwnerID(ctx context.Context, tnow time.Time) (int32, error) {
+func (s *portalPropertyOwnerSource) OwnerID(ctx context.Context, tnow time.Time) (int32, *int32, error) {
 	property, err := s.Store.Impl().RetrievePropertyBySitekey(ctx, s.Sitekey)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to fetch login property", common.ErrAttr(err))
-		return -1, errPortalPropertyNotFound
+		return -1, nil, errPortalPropertyNotFound
 	}
 
-	return property.OrgOwnerID.Int32, nil
+	orgID := new(int32)
+	*orgID = property.OrgID.Int32
+
+	return property.OrgOwnerID.Int32, orgID, nil
 }
 
 func (s *Server) getLogin(w http.ResponseWriter, r *http.Request) (*ViewModel, error) {

--- a/pkg/portal/render.go
+++ b/pkg/portal/render.go
@@ -68,6 +68,7 @@ type RenderConstants struct {
 	APIKeyScopePortalReadWrite string
 	APIKeyScopePortalReadOnly  string
 	PropertiesEndpoint         string
+	All                        string
 }
 
 func NewRenderConstants() *RenderConstants {
@@ -127,6 +128,7 @@ func NewRenderConstants() *RenderConstants {
 		APIKeyScopePortalReadWrite: string(dbgen.ApiKeyScopePortal) + apiKeyReadWriteSuffix,
 		APIKeyScopePortalReadOnly:  string(dbgen.ApiKeyScopePortal) + apiKeyReadOnlySuffix,
 		PropertiesEndpoint:         common.PropertiesEndpoint,
+		All:                        common.All,
 	}
 }
 

--- a/pkg/portal/settings.go
+++ b/pkg/portal/settings.go
@@ -96,6 +96,7 @@ type userAPIKey struct {
 	Secret            string
 	Scope             string
 	RequestsPerMinute int
+	OrgName           string
 	ExpiresSoon       bool
 	ReadOnly          bool
 }
@@ -104,7 +105,9 @@ type settingsAPIKeysRenderContext struct {
 	SettingsCommonRenderContext
 	Name       string
 	NameError  string
+	OrgError   string
 	Keys       []*userAPIKey
+	Orgs       []*userOrg
 	CreateOpen bool
 }
 
@@ -420,10 +423,31 @@ func (s *Server) createAPIKeysSettingsModel(ctx context.Context, user *dbgen.Use
 		commonCtx.ErrorMessage = "Could not load API keys."
 	}
 
-	return &settingsAPIKeysRenderContext{
+	renderCtx := &settingsAPIKeysRenderContext{
 		SettingsCommonRenderContext: commonCtx,
 		Keys:                        apiKeysToUserAPIKeys(keys, time.Now().UTC(), s.IDHasher),
 	}
+
+	if orgs, err := s.Store.Impl().RetrieveUserOrganizations(ctx, user.ID); err == nil {
+		renderCtx.Orgs = orgsToUserOrgs(orgs, s.IDHasher)
+
+		orgNameMap := make(map[int32]string, len(orgs))
+		for _, org := range orgs {
+			orgNameMap[org.Organization.ID] = org.Organization.Name
+		}
+		for i, key := range keys {
+			if key.OrgID.Valid {
+				if name, ok := orgNameMap[key.OrgID.Int32]; ok {
+					renderCtx.Keys[i].OrgName = name
+				} else {
+					// if this shows up in monitoring, rewrite RetrieveUserAPIKeys() to JOIN with Orgs
+					slog.ErrorContext(ctx, "Organization name not found for API key", "keyID", key.ID, "orgID", key.OrgID.Int32)
+				}
+			}
+		}
+	}
+
+	return renderCtx
 }
 
 func (s *Server) getAPIKeysSettings(w http.ResponseWriter, r *http.Request) (*ViewModel, error) {
@@ -600,6 +624,27 @@ func (s *Server) postAPIKeySettings(w http.ResponseWriter, r *http.Request) (*Vi
 		}
 	}
 
+	pgOrgID := db.InvalidInt
+	var orgName string
+	orgIDStr := strings.TrimSpace(r.FormValue(common.ParamOrg))
+	if (orgIDStr != common.All) && (len(orgIDStr) > 0) {
+		var orgID int
+		var oerr error
+		if orgID, oerr = s.IDHasher.Decrypt(orgIDStr); oerr == nil {
+			var org *dbgen.Organization
+			if org, oerr = s.Store.Impl().RetrieveUserOrganization(ctx, user, int32(orgID)); err == nil {
+				pgOrgID = db.Int(org.ID)
+				orgName = org.Name
+			}
+		}
+		if oerr != nil {
+			slog.ErrorContext(ctx, "Failed to retrieve user org", "orgID", orgIDStr, common.ErrAttr(oerr))
+			renderCtx.OrgError = "Selected organization does not exist."
+			renderCtx.CreateOpen = true
+			return &ViewModel{Model: renderCtx, View: settingsAPIKeysContentTemplate}, nil
+		}
+	}
+
 	// current logic is that initial values will be set per plan and adjusted manually in DB if requested by customer
 	burst := max(minAPIKeyRequestsBurst, int32(apiKeyRequestsPerSecond*5))
 	days := apiKeyDaysFromParam(ctx, r.FormValue(common.ParamDays))
@@ -613,10 +658,12 @@ func (s *Server) postAPIKeySettings(w http.ResponseWriter, r *http.Request) (*Vi
 		Period:            period,
 		Scope:             scope,
 		Readonly:          readOnly,
+		OrgID:             pgOrgID,
 	}
 	newKey, auditEvent, err := s.Store.Impl().CreateAPIKey(ctx, user, params)
 	if err == nil {
 		userKey := apiKeyToUserAPIKey(newKey, tnow, s.IDHasher)
+		userKey.OrgName = orgName
 		userKey.Secret = db.UUIDToSecret(newKey.ExternalID)
 		renderCtx.Keys = append(renderCtx.Keys, userKey)
 		renderCtx.SuccessMessage = "API Key created successfully."
@@ -673,6 +720,12 @@ func (s *Server) rotateAPIKey(w http.ResponseWriter, r *http.Request) (*ViewMode
 
 	userKey := apiKeyToUserAPIKey(key, time.Now().UTC(), s.IDHasher)
 	userKey.Secret = db.UUIDToSecret(key.ExternalID)
+
+	if key.OrgID.Valid {
+		if org, err := s.Store.Impl().RetrieveUserOrganization(ctx, user, key.OrgID.Int32); err == nil {
+			userKey.OrgName = org.Name
+		}
+	}
 
 	go common.RunAdHocFunc(common.CopyTraceID(ctx, context.Background()), func(bctx context.Context) error {
 		var anyError error

--- a/pkg/puzzle/verifier.go
+++ b/pkg/puzzle/verifier.go
@@ -39,6 +39,7 @@ const (
 	MaintenanceModeError    VerifyError = 9
 	TestPropertyError       VerifyError = 10
 	IntegrityError          VerifyError = 11
+	OrgScopeError           VerifyError = 12
 	// Add new fields _above_
 	VERIFY_ERRORS_COUNT
 )
@@ -61,6 +62,8 @@ func (verr VerifyError) String() string {
 		return "property-invalid"
 	case WrongOwnerError:
 		return "property-owner-mismatch"
+	case OrgScopeError:
+		return "property-org-scope"
 	case VerifiedBeforeError:
 		return "solution-verified-before"
 	case MaintenanceModeError:
@@ -75,7 +78,7 @@ func (verr VerifyError) String() string {
 }
 
 type OwnerIDSource interface {
-	OwnerID(ctx context.Context, tnow time.Time) (int32, error)
+	OwnerID(ctx context.Context, tnow time.Time) (int32, *int32, error)
 }
 
 type VerifyPayload struct {

--- a/web/layouts/property/settings-move-form.html
+++ b/web/layouts/property/settings-move-form.html
@@ -5,7 +5,7 @@
             <div class="mt-2">
                 <div class="space-y-4">
                     <div>
-                        <label for="{{ .Const.Days }}" class="pc-internal-form-label"> Organization </label>
+                        <label for="{{ .Const.Org }}" class="pc-internal-form-label"> Organization </label>
                         <div class="mt-2">
                             <select name="{{ .Const.Org }}" class="w-full pc-internal-form-select">
                             {{ range $org := $.Params.Orgs }}

--- a/web/layouts/settings-apikeys/form.html
+++ b/web/layouts/settings-apikeys/form.html
@@ -40,6 +40,20 @@
                             </select>
                         </div>
                     </div>
+                    <div>
+                        <label for="{{ .Const.Org }}" class="pc-internal-form-label"> Organization </label>
+                        <div class="mt-2">
+                            <select name="{{ .Const.Org }}" class="w-full pc-internal-form-select">
+                                <option value="{{ .Const.All }}" selected="selected">All</option>
+                            {{ range $org := $.Params.Orgs }}
+                                <option value="{{$org.ID}}">{{ $org.Name }}</option>
+                            {{ end }}
+                            </select>
+                        </div>
+                        {{- if .Params.OrgError -}}
+                        <p class="pc-form-error-text">{{ .Params.OrgError }}</p>
+                        {{- end -}}
+                    </div>
                 </div>
             </div>
         </div>

--- a/web/layouts/settings-apikeys/key.html
+++ b/web/layouts/settings-apikeys/key.html
@@ -22,9 +22,17 @@
                 {{ end }}
             {{ end }}
             {{ if and (ne .Params.Scope .Const.APIKeyScopePuzzle) .Params.ReadOnly }}
-            <p class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">scope: {{ .Params.Scope }} (read)</p>
+            <p class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10" title="read-only scope for {{.Params.Scope}}">scope: {{ .Params.Scope }} (read)</p>
             {{ else }}
-            <p class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">scope: {{ .Params.Scope }}</p>
+            <p class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200" title="read-write scope for {{.Params.Scope}}">scope: {{ .Params.Scope }}</p>
+            {{ end }}
+            {{ if .Params.OrgName }}
+            <p class="inline-flex items-center gap-x-1.5 rounded-md bg-pcslate-50 px-2 py-1 text-xs font-medium text-pclime-600" title="for {{ .Params.OrgName }} Organization">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3 fill-pclime-500" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a1 1 0 110 2h-3a1 1 0 01-1-1v-2a1 1 0 00-1-1H9a1 1 0 00-1 1v2a1 1 0 01-1 1H4a1 1 0 110-2V4zm3 1h2v2H7V5zm2 4H7v2h2V9zm2-4h2v2h-2V5zm2 4h-2v2h2V9z" clip-rule="evenodd" />
+                </svg>
+                {{ .Params.OrgName }}
+            </p>
             {{ end }}
         </div>
         <div class="mt-1 flex items-center gap-x-2 text-xs leading-5 text-gray-500">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Organization-scoped API keys: Create API keys restricted to specific organizations
  * Organization selector in API key creation form
  * Organization scope indicators on API keys in listings

* **Improvements**
  * API operations now enforce organization scope validation, blocking actions outside the authorized organization
  * API responses filtered based on organization scope of the API key

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->