### PR TITLE
Persist other caches between restart too

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,7 +48,6 @@ const (
 	_dbConnectTimeout       = 30 * time.Second
 	_sessionPersistInterval = 10 * time.Second
 	_auditLogInterval       = 10 * time.Second
-	cachePersistSize        = 10_000
 )
 
 const (
@@ -230,7 +229,21 @@ func run(ctx context.Context, cfg common.ConfigStore, stderr io.Writer, listener
 			persistCtx, cancel := context.WithTimeout(context.Background(), healthCheckTime)
 			defer cancel()
 			go common.RunAdHocFunc(persistCtx, func(bctx context.Context) error {
-				return businessDB.SaveCache(bctx, cfg.Get(common.CacheDirKey).Value(), cachePersistSize)
+				cacheDir := cfg.Get(common.CacheDirKey).Value()
+				var errs []error
+				if err := businessDB.SaveCache(bctx, cacheDir); err != nil {
+					errs = append(errs, err)
+				}
+				if err := ipRateLimiter.SaveCache(bctx, cacheDir); err != nil {
+					errs = append(errs, err)
+				}
+				if err := apiServer.Levels.SaveCache(bctx, cacheDir); err != nil {
+					errs = append(errs, err)
+				}
+				if len(errs) > 0 {
+					return fmt.Errorf("cache save errors: %v", errs)
+				}
+				return nil
 			})
 		}
 
@@ -372,7 +385,21 @@ func run(ctx context.Context, cfg common.ConfigStore, stderr io.Writer, listener
 	}()
 
 	go common.RunAdHocFunc(ctx, func(ctx context.Context) error {
-		return businessDB.LoadCache(ctx, cfg.Get(common.CacheDirKey).Value())
+		cacheDir := cfg.Get(common.CacheDirKey).Value()
+		var errs []error
+		if err := businessDB.LoadCache(ctx, cacheDir); err != nil {
+			errs = append(errs, err)
+		}
+		if err := ipRateLimiter.LoadCache(ctx, cacheDir); err != nil {
+			errs = append(errs, err)
+		}
+		if err := apiServer.Levels.LoadCache(ctx, cacheDir); err != nil {
+			errs = append(errs, err)
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("cache load errors: %v", errs)
+		}
+		return nil
 	})
 
 	businessDB.Start(ctx, _auditLogInterval)

--- a/pkg/common/cache.go
+++ b/pkg/common/cache.go
@@ -1,0 +1,145 @@
+package common
+
+import (
+	"context"
+	"encoding/gob"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/maypok86/otter/v2"
+)
+
+func SaveCacheToFile[TKey comparable, TValue any](ctx context.Context, dir, filename string, maxItems int, cache *otter.Cache[TKey, TValue], filter func(TValue) bool) error {
+	if len(dir) == 0 {
+		return nil
+	}
+
+	if _, err := os.Stat(dir); err != nil {
+		if !os.IsNotExist(err) {
+			slog.ErrorContext(ctx, "Failed to stat cache directory", "dir", dir, ErrAttr(err))
+			return err
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			slog.ErrorContext(ctx, "Failed to create cache directory", "dir", dir, ErrAttr(err))
+			return err
+		}
+	}
+
+	filePath := filepath.Join(dir, filename)
+	tmp, err := os.CreateTemp(dir, filename+".*.tmp")
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to create cache tmp file", "dir", dir, ErrAttr(err))
+		return err
+	}
+	tmpPath := tmp.Name()
+	// best-effort cleanup if we bail out before rename
+	defer os.Remove(tmpPath)
+
+	count, err := SaveCacheToWriter(ctx, tmp, cache, maxItems, filter)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to save cache", "file", tmpPath, ErrAttr(err))
+		_ = tmp.Close()
+		return err
+	}
+
+	slog.DebugContext(ctx, "Persisted cached items", "count", count)
+
+	if err := tmp.Sync(); err != nil {
+		slog.ErrorContext(ctx, "Failed to fsync cache file", "file", tmpPath, ErrAttr(err))
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		slog.ErrorContext(ctx, "Failed to close cache tmp file", "file", tmpPath, ErrAttr(err))
+		return err
+	}
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		slog.ErrorContext(ctx, "Failed to rename cache file", "file", filePath, ErrAttr(err))
+		return err
+	}
+
+	return nil
+}
+
+func SaveCacheToWriter[TKey comparable, TValue any](ctx context.Context, w io.Writer, cache *otter.Cache[TKey, TValue], maxItems int, filter func(TValue) bool) (int, error) {
+	enc := gob.NewEncoder(w)
+
+	maximum := cache.GetMaximum()
+	if err := enc.Encode(maximum); err != nil {
+		return 0, err
+	}
+
+	size := uint64(0)
+	count := 0
+	for entry := range cache.Hottest() {
+		if (size >= maximum) || (count >= maxItems) {
+			break
+		}
+
+		if err := ctx.Err(); err != nil {
+			slog.WarnContext(ctx, "Truncated cache due to context cancellation", ErrAttr(err))
+			// it's not reported as error because we care only about best-effort here
+			break
+		}
+
+		if filter != nil && !filter(entry.Value) {
+			continue
+		}
+
+		if err := enc.Encode(entry); err != nil {
+			return count, err
+		}
+
+		size += uint64(entry.Weight)
+		count++
+	}
+	return count, nil
+}
+
+func LoadCacheFromFile[TKey comparable, TValue any](ctx context.Context, dir, filename string, ttl time.Duration, cache *otter.Cache[TKey, TValue]) error {
+	if len(dir) == 0 {
+		return nil
+	}
+
+	filePath := filepath.Join(dir, filename)
+	file, err := os.Open(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		slog.ErrorContext(ctx, "Failed to open cache file", "file", filePath, ErrAttr(err))
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to stat cache file", "file", filePath, ErrAttr(err))
+		return err
+	}
+
+	if age := time.Since(info.ModTime()); age > ttl {
+		slog.WarnContext(ctx, "Ignoring too old cache file", "file", filePath, "age", age.String())
+		return nil
+	}
+
+	if err := LoadCacheFromReader(ctx, file, cache); err != nil {
+		slog.ErrorContext(ctx, "Failed to load cache from file", "file", filePath, ErrAttr(err))
+		if rmErr := os.Remove(filePath); rmErr != nil {
+			slog.ErrorContext(ctx, "Failed to remove corrupted cache file", "file", filePath, ErrAttr(rmErr))
+		} else {
+			slog.DebugContext(ctx, "Removed corrupted cache file", "file", filePath)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func LoadCacheFromReader[TKey comparable, TValue any](ctx context.Context, r io.Reader, cache *otter.Cache[TKey, TValue]) error {
+	return otter.LoadCacheFrom(cache, r)
+}

--- a/pkg/db/business.go
+++ b/pkg/db/business.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -43,6 +41,7 @@ const (
 	negativeCacheTTL         = 5 * time.Minute
 	auditBatchSize           = 100
 	cachePersistFile         = "cache.db"
+	cachePersistSize         = 10_000
 )
 
 type BusinessStore struct {
@@ -225,93 +224,21 @@ func (s *BusinessStore) CheckUserPropertyAccess(ctx context.Context, property *d
 	return false
 }
 
-func (s *BusinessStore) SaveCache(ctx context.Context, dir string, maxItems int) error {
-	if len(dir) == 0 {
-		return nil
+func (s *BusinessStore) SaveCache(ctx context.Context, dir string) error {
+	if memcache, ok := s.Cache.(*memcache[CacheKey, any]); ok && (memcache != nil) {
+		return common.SaveCacheToFile(ctx, dir, cachePersistFile, cachePersistSize, memcache.store, nil)
+	} else {
+		slog.ErrorContext(ctx, "Cache is not otter cache")
 	}
 
-	if _, err := os.Stat(dir); err != nil {
-		if !os.IsNotExist(err) {
-			slog.ErrorContext(ctx, "Failed to stat cache directory", "dir", dir, common.ErrAttr(err))
-			return err
-		}
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			slog.ErrorContext(ctx, "Failed to create cache directory", "dir", dir, common.ErrAttr(err))
-			return err
-		}
-	}
-
-	filePath := filepath.Join(dir, cachePersistFile)
-	tmp, err := os.CreateTemp(dir, cachePersistFile+".*.tmp")
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create cache tmp file", "dir", dir, common.ErrAttr(err))
-		return err
-	}
-	tmpPath := tmp.Name()
-	// best-effort cleanup if we bail out before rename
-	defer os.Remove(tmpPath)
-
-	if err := s.Cache.SaveTo(ctx, tmp, maxItems); err != nil {
-		slog.ErrorContext(ctx, "Failed to save cache", "file", tmpPath, common.ErrAttr(err))
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		slog.ErrorContext(ctx, "Failed to fsync cache file", "file", tmpPath, common.ErrAttr(err))
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		slog.ErrorContext(ctx, "Failed to close cache tmp file", "file", tmpPath, common.ErrAttr(err))
-		return err
-	}
-	if err := os.Rename(tmpPath, filePath); err != nil {
-		slog.ErrorContext(ctx, "Failed to rename cache file", "file", filePath, common.ErrAttr(err))
-		return err
-	}
-
-	slog.InfoContext(ctx, "Saved cache to file successfully", "file", filePath)
 	return nil
 }
 
 func (s *BusinessStore) LoadCache(ctx context.Context, dir string) error {
-	if len(dir) == 0 {
-		return nil
-	}
-
-	filePath := filepath.Join(dir, cachePersistFile)
-	file, err := os.Open(filePath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		slog.ErrorContext(ctx, "Failed to open cache file", "file", filePath, common.ErrAttr(err))
-		return err
-	}
-	defer file.Close()
-
-	info, err := file.Stat()
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to stat cache file", "file", filePath, common.ErrAttr(err))
-		return err
-	}
-
-	if age := time.Since(info.ModTime()); age > defaultCacheTTL {
-		slog.WarnContext(ctx, "Ignoring too old cache file", "file", filePath, "age", age.String())
-		return nil
-	}
-
-	if err := s.Cache.LoadFrom(ctx, file); err != nil {
-		slog.ErrorContext(ctx, "Failed to load cache from file", "file", filePath, common.ErrAttr(err))
-		if rmErr := os.Remove(filePath); rmErr != nil {
-			slog.ErrorContext(ctx, "Failed to remove corrupted cache file", "file", filePath, common.ErrAttr(rmErr))
-		} else {
-			slog.DebugContext(ctx, "Removed corrupted cache file", "file", filePath)
-		}
-
-		return err
+	if memcache, ok := s.Cache.(*memcache[CacheKey, any]); ok && (memcache != nil) {
+		return common.LoadCacheFromFile(ctx, dir, cachePersistFile, defaultCacheTTL, memcache.store)
 	} else {
-		slog.InfoContext(ctx, "Loaded cache from file successfully", "file", filePath)
+		slog.ErrorContext(ctx, "Cache is not otter cache")
 	}
 
 	return nil

--- a/pkg/db/cache.go
+++ b/pkg/db/cache.go
@@ -15,6 +15,7 @@ import (
 	dbgen "github.com/PrivateCaptcha/PrivateCaptcha/pkg/db/generated"
 	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/rules"
 	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/session"
+
 	"github.com/maypok86/otter/v2"
 	"github.com/maypok86/otter/v2/stats"
 )
@@ -221,41 +222,12 @@ func (c *memcache[TKey, TValue]) Delete(ctx context.Context, key TKey) bool {
 }
 
 func (c *memcache[TKey, TValue]) SaveTo(ctx context.Context, w io.Writer, maxItems int) error {
-	enc := gob.NewEncoder(w)
-
-	maximum := c.store.GetMaximum()
-	if err := enc.Encode(maximum); err != nil {
-		return err
-	}
-
-	size := uint64(0)
-	count := 0
-	for entry := range c.store.Hottest() {
-		if (size >= maximum) || (count >= maxItems) {
-			break
-		}
-
-		if err := ctx.Err(); err != nil {
-			slog.WarnContext(ctx, "Truncated cache due to context cancellation", common.ErrAttr(err))
-			// it's not reported as error because we care only about best-effort here
-			break
-		}
-
-		if err := enc.Encode(entry); err != nil {
-			return err
-		}
-
-		size += uint64(entry.Weight)
-		count++
-	}
-
-	slog.DebugContext(ctx, "Persisted cached items", "count", count)
-
-	return nil
+	_, err := common.SaveCacheToWriter(ctx, w, c.store, maxItems, nil)
+	return err
 }
 
-func (c *memcache[TKey, TValue]) LoadFrom(_ context.Context, r io.Reader) error {
-	return otter.LoadCacheFrom(c.store, r)
+func (c *memcache[TKey, TValue]) LoadFrom(ctx context.Context, r io.Reader) error {
+	return common.LoadCacheFromReader(ctx, r, c.store)
 }
 
 type CacheKeyPrefix byte

--- a/pkg/difficulty/levels.go
+++ b/pkg/difficulty/levels.go
@@ -19,6 +19,7 @@ var (
 )
 
 const (
+	userBucketsCacheFilename   = "user_buckets.gob"
 	defaultBackpressureTimeout = 10 * time.Millisecond
 )
 
@@ -288,4 +289,13 @@ func (l *Levels) backfillDifficulty(ctx context.Context, cacheDuration time.Dura
 	}
 
 	slog.DebugContext(ctx, "Finished backfilling difficulty")
+}
+
+func (l *Levels) SaveCache(ctx context.Context, dir string) error {
+	const cachePersistSize = 1_000
+	return l.userBuckets.SaveCache(ctx, dir, userBucketsCacheFilename, cachePersistSize, time.Now())
+}
+
+func (l *Levels) LoadCache(ctx context.Context, dir string) error {
+	return l.userBuckets.LoadCache(ctx, dir, userBucketsCacheFilename)
 }

--- a/pkg/leakybucket/leakybucket.go
+++ b/pkg/leakybucket/leakybucket.go
@@ -1,6 +1,8 @@
 package leakybucket
 
 import (
+	"bytes"
+	"encoding/gob"
 	"time"
 )
 
@@ -30,6 +32,48 @@ type ConstLeakyBucket[TKey comparable] struct {
 	// each {leakInterval} we loose 1 bucket level
 	// e.g. to have 5 levels/second leak rate use {leakInterval = time.Second / 5}
 	leakInterval time.Duration
+}
+
+func (lb *ConstLeakyBucket[TKey]) GobEncode() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(lb.key); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(lb.lastAccessTime); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(lb.level); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(lb.capacity); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(lb.leakInterval); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (lb *ConstLeakyBucket[TKey]) GobDecode(data []byte) error {
+	buf := bytes.NewBuffer(data)
+	dec := gob.NewDecoder(buf)
+	if err := dec.Decode(&lb.key); err != nil {
+		return err
+	}
+	if err := dec.Decode(&lb.lastAccessTime); err != nil {
+		return err
+	}
+	if err := dec.Decode(&lb.level); err != nil {
+		return err
+	}
+	if err := dec.Decode(&lb.capacity); err != nil {
+		return err
+	}
+	if err := dec.Decode(&lb.leakInterval); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (lb *ConstLeakyBucket[TKey]) Init(key TKey, capacity TLevel, leakInterval time.Duration, tnow time.Time) {
@@ -109,6 +153,42 @@ type VarLeakyBucket[TKey comparable] struct {
 	// total count of items added to the bucket. NOTE: in the unlikely case of uint64 overflow
 	// we just reset all stats and continue as usual
 	count uint64
+}
+
+func (lb *VarLeakyBucket[TKey]) GobEncode() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(&lb.ConstLeakyBucket); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(lb.leakRate); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(lb.pendingSum); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(lb.count); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (lb *VarLeakyBucket[TKey]) GobDecode(data []byte) error {
+	buf := bytes.NewBuffer(data)
+	dec := gob.NewDecoder(buf)
+	if err := dec.Decode(&lb.ConstLeakyBucket); err != nil {
+		return err
+	}
+	if err := dec.Decode(&lb.leakRate); err != nil {
+		return err
+	}
+	if err := dec.Decode(&lb.pendingSum); err != nil {
+		return err
+	}
+	if err := dec.Decode(&lb.count); err != nil {
+		return err
+	}
+	return nil
 }
 
 func NewVarBucket[TKey comparable](key TKey, capacity TLevel, leakInterval time.Duration, t time.Time) *VarLeakyBucket[TKey] {

--- a/pkg/leakybucket/leakybucket_test.go
+++ b/pkg/leakybucket/leakybucket_test.go
@@ -253,3 +253,76 @@ func TestVarLeakyBucketAverage(t *testing.T) {
 		})
 	}
 }
+
+func TestConstLeakyBucketGob(t *testing.T) {
+	tnow := time.Now()
+	b1 := NewConstBucket("test-key", 100, 10*time.Millisecond, tnow)
+	// Apply some usage to alter state
+	b1.Add(tnow, 50)
+
+	enc, err := b1.GobEncode()
+	if err != nil {
+		t.Fatalf("GobEncode failed: %v", err)
+	}
+
+	b2 := &ConstLeakyBucket[string]{}
+	err = b2.GobDecode(enc)
+	if err != nil {
+		t.Fatalf("GobDecode failed: %v", err)
+	}
+
+	if b1.key != b2.key {
+		t.Errorf("key mismatch: %v != %v", b1.key, b2.key)
+	}
+	if b1.capacity != b2.capacity {
+		t.Errorf("capacity mismatch: %v != %v", b1.capacity, b2.capacity)
+	}
+	if b1.leakInterval != b2.leakInterval {
+		t.Errorf("leakInterval mismatch: %v != %v", b1.leakInterval, b2.leakInterval)
+	}
+	if b1.level != b2.level {
+		t.Errorf("level mismatch: %v != %v", b1.level, b2.level)
+	}
+	if !b1.lastAccessTime.Equal(b2.lastAccessTime) {
+		t.Errorf("lastAccessTime mismatch: %v != %v", b1.lastAccessTime, b2.lastAccessTime)
+	}
+}
+
+func TestVarLeakyBucketGob(t *testing.T) {
+	tnow := time.Now()
+	b1 := NewVarBucket("test-key", 100, 10*time.Millisecond, tnow)
+	// Apply some usage to alter state
+	b1.Add(tnow, 50)
+
+	// Alter internal VarLeakyBucket specific fields to test encoding
+	b1.leakRate = 1.5
+	b1.pendingSum = 10
+	b1.count = 5
+
+	enc, err := b1.GobEncode()
+	if err != nil {
+		t.Fatalf("GobEncode failed: %v", err)
+	}
+
+	b2 := &VarLeakyBucket[string]{}
+	err = b2.GobDecode(enc)
+	if err != nil {
+		t.Fatalf("GobDecode failed: %v", err)
+	}
+
+	// Base fields
+	if b1.key != b2.key || b1.capacity != b2.capacity || b1.leakInterval != b2.leakInterval || b1.level != b2.level || !b1.lastAccessTime.Equal(b2.lastAccessTime) {
+		t.Errorf("Decoded base fields mismatch: got %+v, want %+v", b2, b1)
+	}
+
+	// Var specific fields
+	if b1.leakRate != b2.leakRate {
+		t.Errorf("leakRate mismatch: %v != %v", b1.leakRate, b2.leakRate)
+	}
+	if b1.pendingSum != b2.pendingSum {
+		t.Errorf("pendingSum mismatch: %v != %v", b1.pendingSum, b2.pendingSum)
+	}
+	if b1.count != b2.count {
+		t.Errorf("count mismatch: %v != %v", b1.count, b2.count)
+	}
+}

--- a/pkg/leakybucket/manager.go
+++ b/pkg/leakybucket/manager.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/common"
 	"github.com/maypok86/otter/v2"
 )
 
@@ -178,4 +179,19 @@ func (m *Manager[TKey, T, TBucket]) AddEx(key TKey, n TLevel, tnow time.Time, in
 
 func (m *Manager[TKey, T, TBucket]) Clear() {
 	m.buckets.InvalidateAll()
+}
+
+func (m *Manager[TKey, T, TBucket]) SaveCache(ctx context.Context, dir, filename string, maxItems int, tnow time.Time) error {
+	filter := func(b TBucket) bool {
+		// we only save buckets that are not "full" (which means level > 0, so there is some usage)
+		return b.Level(tnow) > 0
+	}
+	return common.SaveCacheToFile(ctx, dir, filename, maxItems, m.buckets, filter)
+}
+
+func (m *Manager[TKey, T, TBucket]) LoadCache(ctx context.Context, dir, filename string) error {
+	m.mu.RLock()
+	ttl := time.Duration(m.capacity) * m.leakInterval
+	m.mu.RUnlock()
+	return common.LoadCacheFromFile(ctx, dir, filename, ttl, m.buckets)
 }

--- a/pkg/leakybucket/manager_test.go
+++ b/pkg/leakybucket/manager_test.go
@@ -1,10 +1,14 @@
 package leakybucket
 
 import (
+	"bytes"
+	"context"
 	"net/netip"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/common"
 )
 
 func TestManagerAdd(t *testing.T) {
@@ -237,5 +241,91 @@ func TestManagerIPAddrAddDefault(t *testing.T) {
 	}
 	if result.Added != 0 {
 		t.Errorf("Managed to add to full bucket")
+	}
+}
+
+func TestManagerCacheConstLeakyBucket(t *testing.T) {
+	ctx := context.TODO()
+
+	manager := NewManager[string, ConstLeakyBucket[string], *ConstLeakyBucket[string]](100, 10, 10*time.Millisecond)
+
+	tnow := time.Now()
+	manager.Add("user1", 5, tnow)
+	manager.Add("user3", 10, tnow)
+
+	var buf bytes.Buffer
+
+	filter := func(b *ConstLeakyBucket[string]) bool {
+		return b.Level(tnow) > 0
+	}
+
+	_, err := common.SaveCacheToWriter(ctx, &buf, manager.buckets, 100, filter)
+	if err != nil {
+		t.Fatalf("SaveCacheToWriter failed: %v", err)
+	}
+
+	manager2 := NewManager[string, ConstLeakyBucket[string], *ConstLeakyBucket[string]](100, 10, 10*time.Millisecond)
+	err = common.LoadCacheFromReader(ctx, &buf, manager2.buckets)
+	if err != nil {
+		t.Fatalf("LoadCacheFromReader failed: %v", err)
+	}
+
+	lvl1, ok1 := manager2.Level("user1", tnow)
+	if !ok1 || lvl1 != 5 {
+		t.Errorf("user1 expected level 5, got %v (ok=%v)", lvl1, ok1)
+	}
+
+	lvl3, ok3 := manager2.Level("user3", tnow)
+	if !ok3 || lvl3 != 10 {
+		t.Errorf("user3 expected level 10, got %v (ok=%v)", lvl3, ok3)
+	}
+
+	lvl1b, _ := manager2.Level("user1", tnow.Add(100*time.Millisecond))
+	if lvl1b != 0 {
+		t.Errorf("expected user1 level to leak to 0, got %v", lvl1b)
+	}
+}
+
+func TestManagerCacheVarLeakyBucket(t *testing.T) {
+	ctx := context.TODO()
+
+	manager := NewManager[int32, VarLeakyBucket[int32], *VarLeakyBucket[int32]](100, 10, 10*time.Millisecond)
+
+	tnow := time.Now()
+	manager.Add(1, 5, tnow)
+	manager.Add(2, 10, tnow)
+
+	var buf bytes.Buffer
+
+	filter := func(b *VarLeakyBucket[int32]) bool {
+		return b.Level(tnow) > 0
+	}
+
+	_, err := common.SaveCacheToWriter(ctx, &buf, manager.buckets, 100, filter)
+	if err != nil {
+		t.Fatalf("SaveCacheToWriter failed: %v", err)
+	}
+
+	manager2 := NewManager[int32, VarLeakyBucket[int32], *VarLeakyBucket[int32]](100, 10, 10*time.Millisecond)
+	err = common.LoadCacheFromReader(ctx, &buf, manager2.buckets)
+	if err != nil {
+		t.Fatalf("LoadCacheFromReader failed: %v", err)
+	}
+
+	lvl1, ok1 := manager2.Level(1, tnow)
+	if !ok1 || lvl1 != 5 {
+		t.Errorf("1 expected level 5, got %v (ok=%v)", lvl1, ok1)
+	}
+
+	lvl2, ok2 := manager2.Level(2, tnow)
+	if !ok2 || lvl2 != 10 {
+		t.Errorf("2 expected level 10, got %v (ok=%v)", lvl2, ok2)
+	}
+
+	// Verify the updated limits persisted
+	// Waiting 100ms should leak levels (since it leaks based on running rate, approx 1 per 10ms initially)
+	lvl2b, _ := manager2.Level(2, tnow.Add(200*time.Millisecond))
+	if lvl2b != 0 {
+		t.Errorf("expected 2 level to leak to 0, got %v", lvl2b)
 	}
 }

--- a/pkg/ratelimit/http.go
+++ b/pkg/ratelimit/http.go
@@ -44,6 +44,9 @@ type HTTPRateLimiter interface {
 	RateLimitExFunc(initCapacity leakybucket.TLevel, initLeakInterval time.Duration) func(next http.Handler) http.Handler
 	UpdateRequestLimits(r *http.Request, capacity leakybucket.TLevel, leakInterval time.Duration)
 	UpdateLimits(capacity leakybucket.TLevel, leakInterval time.Duration)
+	Clear()
+	SaveCache(ctx context.Context, dir string) error
+	LoadCache(ctx context.Context, dir string) error
 }
 
 type httpRateLimiter[TKey comparable] struct {
@@ -147,4 +150,21 @@ func (l *httpRateLimiter[TKey]) setRateLimitHeaders(w http.ResponseWriter, addRe
 		vi := int(math.Max(1.0, seconds+0.5))
 		headers[retryAfterHeader] = []string{strconv.Itoa(vi)}
 	}
+}
+
+func (l *httpRateLimiter[TKey]) Clear() {
+	l.buckets.Clear()
+}
+
+const (
+	ipRateLimiterCacheFilename = "ip_rate_limiter.gob"
+	cachePersistSize           = 1_000
+)
+
+func (l *httpRateLimiter[TKey]) SaveCache(ctx context.Context, dir string) error {
+	return l.buckets.SaveCache(ctx, dir, ipRateLimiterCacheFilename, cachePersistSize, time.Now())
+}
+
+func (l *httpRateLimiter[TKey]) LoadCache(ctx context.Context, dir string) error {
+	return l.buckets.LoadCache(ctx, dir, ipRateLimiterCacheFilename)
 }

--- a/pkg/ratelimit/stub.go
+++ b/pkg/ratelimit/stub.go
@@ -52,3 +52,10 @@ func (srl *StubRateLimiter) UpdateRequestLimits(r *http.Request, capacity leakyb
 func (srl *StubRateLimiter) UpdateLimits(capacity leakybucket.TLevel, leakInterval time.Duration) {
 	// BUMP
 }
+
+func (srl *StubRateLimiter) Clear() {}
+func (srl *StubRateLimiter) SaveCache(ctx context.Context, dir string) error {
+	return nil
+}
+
+func (srl *StubRateLimiter) LoadCache(ctx context.Context, dir string) error { return nil }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cache persistence for rate limiting and difficulty level management
  * Rate limiter state and user difficulty buckets now persist across server restarts
  
* **Improvements**
  * Enhanced multi-component cache handling during server startup and shutdown for greater reliability
  * Improved cache initialization with configurable time intervals for database connections and cache operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->