### PR TITLE
Transfer limits

### DIFF
--- a/pkg/portal/form_test.go
+++ b/pkg/portal/form_test.go
@@ -345,7 +345,8 @@ func TestGetFormDashboardIntegrationsTab(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, "https://api.privatecaptcha.com/form/"+db.UUIDToString(form.ExternalID)) {
+	expectedFormURL := server.APIURL + "/form/" + db.UUIDToString(form.ExternalID)
+	if !strings.Contains(body, expectedFormURL) {
 		t.Fatal("expected form action in integrations snippet")
 	}
 	if !strings.Contains(body, db.UUIDToSiteKey(property.ExternalID)) {

--- a/pkg/portal/org_enterprise.go
+++ b/pkg/portal/org_enterprise.go
@@ -495,6 +495,72 @@ func (s *Server) deleteOrg(w http.ResponseWriter, r *http.Request) {
 	common.Redirect(s.RelURL("/"), http.StatusOK, w, r)
 }
 
+func (s *Server) validateTransferOrgLimits(ctx context.Context, org *dbgen.Organization, newOwner *dbgen.User) int {
+	var subscr *dbgen.Subscription
+	var err error
+
+	if newOwner.SubscriptionID.Valid {
+		subscr, err = s.Store.Impl().RetrieveSubscription(ctx, newOwner.SubscriptionID.Int32)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to retrieve destination user subscription", "userID", newOwner.ID, common.ErrAttr(err))
+			return http.StatusInternalServerError
+		}
+	}
+
+	propertiesLimit, err := s.SubscriptionLimits.PropertiesLimit(ctx, subscr)
+	if err != nil {
+		if err == db.ErrNoActiveSubscription {
+			return http.StatusPaymentRequired
+		}
+
+		slog.ErrorContext(ctx, "Failed to retrieve destination user property limit", "userID", newOwner.ID, common.ErrAttr(err))
+		return http.StatusInternalServerError
+	}
+
+	if propertiesLimit > 0 {
+		ok, extra, err := s.SubscriptionLimits.CheckPropertiesLimit(ctx, newOwner.ID, subscr)
+		if err != nil {
+			if err == db.ErrNoActiveSubscription {
+				return http.StatusPaymentRequired
+			}
+
+			slog.ErrorContext(ctx, "Failed to check destination user property limit", "userID", newOwner.ID, common.ErrAttr(err))
+			return http.StatusInternalServerError
+		}
+
+		if !ok && extra > 0 {
+			slog.WarnContext(ctx, "Destination user is already above properties limit", "userID", newOwner.ID, "orgID", org.ID, "extra", extra)
+			return http.StatusPaymentRequired
+		}
+
+		orgPropertiesCount, err := s.Store.Impl().RetrieveOrgPropertiesCount(ctx, org.ID)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to retrieve organization properties count", "orgID", org.ID, common.ErrAttr(err))
+			return http.StatusInternalServerError
+		}
+
+		if int(orgPropertiesCount) > (-extra) {
+			slog.WarnContext(ctx, "Destination user would exceed properties limit after org transfer", "userID", newOwner.ID,
+				"orgID", org.ID, "orgPropertiesCount", orgPropertiesCount, "extra", extra)
+			return http.StatusPaymentRequired
+		}
+	}
+
+	if ok, extra, err := s.SubscriptionLimits.CheckFormsLimit(ctx, org.ID, subscr); err != nil {
+		if err == db.ErrNoActiveSubscription {
+			return http.StatusPaymentRequired
+		}
+
+		slog.ErrorContext(ctx, "Failed to check destination org forms limit", "userID", newOwner.ID, "orgID", org.ID, common.ErrAttr(err))
+		return http.StatusInternalServerError
+	} else if !ok && extra > 0 {
+		slog.WarnContext(ctx, "Destination user would exceed forms limit after org transfer", "userID", newOwner.ID, "orgID", org.ID, "extra", extra)
+		return http.StatusPaymentRequired
+	}
+
+	return 0
+}
+
 func (s *Server) transferOrg(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -550,75 +616,8 @@ func (s *Server) transferOrg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	newOwner := &members[idx].User
-
-	var subscr *dbgen.Subscription
-	if newOwner.SubscriptionID.Valid {
-		subscr, err = s.Store.Impl().RetrieveSubscription(ctx, newOwner.SubscriptionID.Int32)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to retrieve destination user subscription", "userID", newOwner.ID, common.ErrAttr(err))
-			s.RedirectError(http.StatusInternalServerError, w, r)
-			return
-		}
-	}
-
-	propertiesLimit, err := s.SubscriptionLimits.PropertiesLimit(ctx, subscr)
-	if err != nil {
-		if err == db.ErrNoActiveSubscription {
-			s.RedirectError(http.StatusPaymentRequired, w, r)
-			return
-		}
-
-		slog.ErrorContext(ctx, "Failed to retrieve destination user property limit", "userID", newOwner.ID, common.ErrAttr(err))
-		s.RedirectError(http.StatusInternalServerError, w, r)
-		return
-	}
-
-	if propertiesLimit > 0 {
-		ok, extra, err := s.SubscriptionLimits.CheckPropertiesLimit(ctx, newOwner.ID, subscr)
-		if err != nil {
-			if err == db.ErrNoActiveSubscription {
-				s.RedirectError(http.StatusPaymentRequired, w, r)
-				return
-			}
-
-			slog.ErrorContext(ctx, "Failed to check destination user property limit", "userID", newOwner.ID, common.ErrAttr(err))
-			s.RedirectError(http.StatusInternalServerError, w, r)
-			return
-		}
-
-		if !ok && extra > 0 {
-			slog.WarnContext(ctx, "Destination user is already above properties limit", "userID", newOwner.ID, "orgID", org.ID, "extra", extra)
-			s.RedirectError(http.StatusPaymentRequired, w, r)
-			return
-		}
-
-		orgPropertiesCount, err := s.Store.Impl().RetrieveOrgPropertiesCount(ctx, org.ID)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to retrieve organization properties count", "orgID", org.ID, common.ErrAttr(err))
-			s.RedirectError(http.StatusInternalServerError, w, r)
-			return
-		}
-
-		if int(orgPropertiesCount) > (-extra) {
-			slog.WarnContext(ctx, "Destination user would exceed properties limit after org transfer", "userID", newOwner.ID,
-				"orgID", org.ID, "orgPropertiesCount", orgPropertiesCount, "extra", extra)
-			s.RedirectError(http.StatusPaymentRequired, w, r)
-			return
-		}
-	}
-
-	if ok, extra, err := s.SubscriptionLimits.CheckFormsLimit(ctx, org.ID, subscr); err != nil {
-		if err == db.ErrNoActiveSubscription {
-			s.RedirectError(http.StatusPaymentRequired, w, r)
-			return
-		}
-
-		slog.ErrorContext(ctx, "Failed to check destination org forms limit", "userID", newOwner.ID, "orgID", org.ID, common.ErrAttr(err))
-		s.RedirectError(http.StatusInternalServerError, w, r)
-		return
-	} else if !ok && extra > 0 {
-		slog.WarnContext(ctx, "Destination user would exceed forms limit after org transfer", "userID", newOwner.ID, "orgID", org.ID, "extra", extra)
-		s.RedirectError(http.StatusPaymentRequired, w, r)
+	if code := s.validateTransferOrgLimits(ctx, org, newOwner); code > 0 {
+		s.RedirectError(code, w, r)
 		return
 	}
 

--- a/pkg/portal/org_enterprise.go
+++ b/pkg/portal/org_enterprise.go
@@ -551,6 +551,77 @@ func (s *Server) transferOrg(w http.ResponseWriter, r *http.Request) {
 
 	newOwner := &members[idx].User
 
+	var subscr *dbgen.Subscription
+	if newOwner.SubscriptionID.Valid {
+		subscr, err = s.Store.Impl().RetrieveSubscription(ctx, newOwner.SubscriptionID.Int32)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to retrieve destination user subscription", "userID", newOwner.ID, common.ErrAttr(err))
+			s.RedirectError(http.StatusInternalServerError, w, r)
+			return
+		}
+	}
+
+	propertiesLimit, err := s.SubscriptionLimits.PropertiesLimit(ctx, subscr)
+	if err != nil {
+		if err == db.ErrNoActiveSubscription {
+			s.RedirectError(http.StatusPaymentRequired, w, r)
+			return
+		}
+
+		slog.ErrorContext(ctx, "Failed to retrieve destination user property limit", "userID", newOwner.ID, common.ErrAttr(err))
+		s.RedirectError(http.StatusInternalServerError, w, r)
+		return
+	}
+
+	if propertiesLimit > 0 {
+		ok, extra, err := s.SubscriptionLimits.CheckPropertiesLimit(ctx, newOwner.ID, subscr)
+		if err != nil {
+			if err == db.ErrNoActiveSubscription {
+				s.RedirectError(http.StatusPaymentRequired, w, r)
+				return
+			}
+
+			slog.ErrorContext(ctx, "Failed to check destination user property limit", "userID", newOwner.ID, common.ErrAttr(err))
+			s.RedirectError(http.StatusInternalServerError, w, r)
+			return
+		}
+
+		if !ok && extra > 0 {
+			slog.WarnContext(ctx, "Destination user is already above properties limit", "userID", newOwner.ID, "orgID", org.ID, "extra", extra)
+			s.RedirectError(http.StatusPaymentRequired, w, r)
+			return
+		}
+
+		orgPropertiesCount, err := s.Store.Impl().RetrieveOrgPropertiesCount(ctx, org.ID)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to retrieve organization properties count", "orgID", org.ID, common.ErrAttr(err))
+			s.RedirectError(http.StatusInternalServerError, w, r)
+			return
+		}
+
+		if int(orgPropertiesCount) > (-extra) {
+			slog.WarnContext(ctx, "Destination user would exceed properties limit after org transfer", "userID", newOwner.ID,
+				"orgID", org.ID, "orgPropertiesCount", orgPropertiesCount, "extra", extra)
+			s.RedirectError(http.StatusPaymentRequired, w, r)
+			return
+		}
+	}
+
+	if ok, extra, err := s.SubscriptionLimits.CheckFormsLimit(ctx, org.ID, subscr); err != nil {
+		if err == db.ErrNoActiveSubscription {
+			s.RedirectError(http.StatusPaymentRequired, w, r)
+			return
+		}
+
+		slog.ErrorContext(ctx, "Failed to check destination org forms limit", "userID", newOwner.ID, "orgID", org.ID, common.ErrAttr(err))
+		s.RedirectError(http.StatusInternalServerError, w, r)
+		return
+	} else if !ok && extra > 0 {
+		slog.WarnContext(ctx, "Destination user would exceed forms limit after org transfer", "userID", newOwner.ID, "orgID", org.ID, "extra", extra)
+		s.RedirectError(http.StatusPaymentRequired, w, r)
+		return
+	}
+
 	auditEvents, err := s.Store.WithTx(ctx, func(impl *db.BusinessStoreImpl) ([]*common.AuditLogEvent, error) {
 		return impl.TransferOrganization(ctx, user, org, newOwner)
 	})

--- a/pkg/portal/org_test.go
+++ b/pkg/portal/org_test.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,29 @@ import (
 	db_tests "github.com/PrivateCaptcha/PrivateCaptcha/pkg/db/tests"
 	portal_tests "github.com/PrivateCaptcha/PrivateCaptcha/pkg/portal/tests"
 )
+
+type transferOrgSubscriptionLimitsStub struct {
+	db.StubSubscriptionLimits
+	propertiesLimit int
+	propertiesOK    bool
+	propertiesExtra int
+	propertiesErr   error
+	formsOK         bool
+	formsExtra      int
+	formsErr        error
+}
+
+func (s transferOrgSubscriptionLimitsStub) CheckPropertiesLimit(ctx context.Context, userID int32, subscr *dbgen.Subscription) (bool, int, error) {
+	return s.propertiesOK, s.propertiesExtra, s.propertiesErr
+}
+
+func (s transferOrgSubscriptionLimitsStub) CheckFormsLimit(ctx context.Context, orgID int32, subscr *dbgen.Subscription) (bool, int, error) {
+	return s.formsOK, s.formsExtra, s.formsErr
+}
+
+func (s transferOrgSubscriptionLimitsStub) PropertiesLimit(ctx context.Context, subscr *dbgen.Subscription) (int, error) {
+	return s.propertiesLimit, s.propertiesErr
+}
 
 func TestGetAnotherUsersOrg(t *testing.T) {
 	if testing.Short() {
@@ -1037,6 +1061,280 @@ func TestTransferOrgToInvitedMember(t *testing.T) {
 	if !strings.HasPrefix(location.String(), "/"+common.ErrorEndpoint) {
 		t.Errorf("Expected error redirect, got: %s", location.String())
 	}
+}
+
+func TestTransferOrgDestinationPropertyLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := t.Context()
+	owner, org, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name()+"owner", testPlan)
+	if err != nil {
+		t.Fatalf("Failed to create owner account: %v", err)
+	}
+
+	newOwner, _, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name()+"member", testPlan)
+	if err != nil {
+		t.Fatalf("Failed to create target account: %v", err)
+	}
+
+	if _, _, err := store.Impl().CreateNewProperty(ctx, db_tests.CreateNewPropertyParams(owner.ID, t.Name()+".example.com"), org); err != nil {
+		t.Fatalf("Failed to create org property: %v", err)
+	}
+
+	if _, err := store.Impl().InviteUserToOrg(ctx, owner, org, newOwner); err != nil {
+		t.Fatalf("Failed to invite target owner: %v", err)
+	}
+	if _, err := store.Impl().JoinOrg(ctx, org.ID, newOwner); err != nil {
+		t.Fatalf("Failed to join target owner: %v", err)
+	}
+
+	originalLimits := server.SubscriptionLimits
+	server.SubscriptionLimits = transferOrgSubscriptionLimitsStub{
+		propertiesLimit: 1,
+		propertiesOK:    false,
+		propertiesExtra: 0,
+		formsOK:         true,
+	}
+	defer func() {
+		server.SubscriptionLimits = originalLimits
+	}()
+
+	srv := http.NewServeMux()
+	server.Setup(portalDomain(), common.NoopMiddleware).Register(srv)
+
+	cookie, err := portal_tests.AuthenticateSuite(ctx, owner.Email, srv, server.XSRF, server.Sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Set(common.ParamCSRFToken, server.XSRF.Token(strconv.Itoa(int(owner.ID))))
+	form.Set(common.ParamUser, server.IDHasher.Encrypt(int(newOwner.ID)))
+
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/org/%s/transfer", server.IDHasher.Encrypt(int(org.ID))), strings.NewReader(form.Encode()))
+	req.AddCookie(cookie)
+	req.Header.Set(common.HeaderContentType, common.ContentTypeURLEncoded)
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("Expected redirect, got %d", w.Code)
+	}
+
+	location, _ := w.Result().Location()
+	if path := location.String(); path != "/"+common.ErrorEndpoint+"/"+strconv.Itoa(http.StatusPaymentRequired) {
+		t.Fatalf("Expected payment required redirect, got %s", path)
+	}
+
+	ownerOrgs, err := store.Impl().RetrieveUserOrganizations(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ownerStillOwnsOrg := false
+	for _, o := range ownerOrgs {
+		if o.Organization.ID == org.ID && o.Level == dbgen.AccessLevelOwner {
+			ownerStillOwnsOrg = true
+			break
+		}
+	}
+	if !ownerStillOwnsOrg {
+		t.Fatal("Expected original owner to keep organization")
+	}
+
+	newOwnerOrgs, err := store.Impl().RetrieveUserOrganizations(ctx, newOwner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, o := range newOwnerOrgs {
+		if o.Organization.ID == org.ID && o.Level == dbgen.AccessLevelOwner {
+			t.Fatal("Did not expect destination user to become owner")
+		}
+	}
+}
+
+func TestTransferOrgDestinationFormLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := t.Context()
+	owner, org, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name()+"owner", testPlan)
+	if err != nil {
+		t.Fatalf("Failed to create owner account: %v", err)
+	}
+
+	newOwner, _, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name()+"member", testPlan)
+	if err != nil {
+		t.Fatalf("Failed to create target account: %v", err)
+	}
+
+	if _, _, _, err := store.Impl().CreateNewForm(ctx,
+		db_tests.CreateNewPropertyParams(owner.ID, t.Name()+".example.com"),
+		&dbgen.CreateFormParams{Name: t.Name(), URL: "https://hooks.example.com/submit/form", Fields: []byte(`{}`), Enabled: true},
+		org,
+	); err != nil {
+		t.Fatalf("Failed to create org form: %v", err)
+	}
+
+	if _, err := store.Impl().InviteUserToOrg(ctx, owner, org, newOwner); err != nil {
+		t.Fatalf("Failed to invite target owner: %v", err)
+	}
+	if _, err := store.Impl().JoinOrg(ctx, org.ID, newOwner); err != nil {
+		t.Fatalf("Failed to join target owner: %v", err)
+	}
+
+	originalLimits := server.SubscriptionLimits
+	server.SubscriptionLimits = transferOrgSubscriptionLimitsStub{
+		propertiesOK: true,
+		formsOK:      false,
+		formsExtra:   1,
+	}
+	defer func() {
+		server.SubscriptionLimits = originalLimits
+	}()
+
+	srv := http.NewServeMux()
+	server.Setup(portalDomain(), common.NoopMiddleware).Register(srv)
+
+	cookie, err := portal_tests.AuthenticateSuite(ctx, owner.Email, srv, server.XSRF, server.Sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Set(common.ParamCSRFToken, server.XSRF.Token(strconv.Itoa(int(owner.ID))))
+	form.Set(common.ParamUser, server.IDHasher.Encrypt(int(newOwner.ID)))
+
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/org/%s/transfer", server.IDHasher.Encrypt(int(org.ID))), strings.NewReader(form.Encode()))
+	req.AddCookie(cookie)
+	req.Header.Set(common.HeaderContentType, common.ContentTypeURLEncoded)
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("Expected redirect, got %d", w.Code)
+	}
+
+	location, _ := w.Result().Location()
+	if path := location.String(); path != "/"+common.ErrorEndpoint+"/"+strconv.Itoa(http.StatusPaymentRequired) {
+		t.Fatalf("Expected payment required redirect, got %s", path)
+	}
+
+	ownerOrgs, err := store.Impl().RetrieveUserOrganizations(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ownerStillOwnsOrg := false
+	for _, o := range ownerOrgs {
+		if o.Organization.ID == org.ID && o.Level == dbgen.AccessLevelOwner {
+			ownerStillOwnsOrg = true
+			break
+		}
+	}
+	if !ownerStillOwnsOrg {
+		t.Fatal("Expected original owner to keep organization")
+	}
+
+	newOwnerOrgs, err := store.Impl().RetrieveUserOrganizations(ctx, newOwner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, o := range newOwnerOrgs {
+		if o.Organization.ID == org.ID && o.Level == dbgen.AccessLevelOwner {
+			t.Fatal("Did not expect destination user to become owner")
+		}
+	}
+}
+
+func TestTransferOrgDestinationExactFormLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := t.Context()
+	owner, org, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name()+"owner", testPlan)
+	if err != nil {
+		t.Fatalf("Failed to create owner account: %v", err)
+	}
+
+	newOwner, _, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name()+"member", testPlan)
+	if err != nil {
+		t.Fatalf("Failed to create target account: %v", err)
+	}
+
+	if _, _, _, err := store.Impl().CreateNewForm(ctx,
+		db_tests.CreateNewPropertyParams(owner.ID, t.Name()+".example.com"),
+		&dbgen.CreateFormParams{Name: t.Name(), URL: "https://hooks.example.com/submit/form", Fields: []byte(`{}`), Enabled: true},
+		org,
+	); err != nil {
+		t.Fatalf("Failed to create org form: %v", err)
+	}
+
+	if _, err := store.Impl().InviteUserToOrg(ctx, owner, org, newOwner); err != nil {
+		t.Fatalf("Failed to invite target owner: %v", err)
+	}
+	if _, err := store.Impl().JoinOrg(ctx, org.ID, newOwner); err != nil {
+		t.Fatalf("Failed to join target owner: %v", err)
+	}
+
+	originalLimits := server.SubscriptionLimits
+	server.SubscriptionLimits = transferOrgSubscriptionLimitsStub{
+		propertiesOK: true,
+		formsOK:      false,
+		formsExtra:   0,
+	}
+	defer func() {
+		server.SubscriptionLimits = originalLimits
+	}()
+
+	srv := http.NewServeMux()
+	server.Setup(portalDomain(), common.NoopMiddleware).Register(srv)
+
+	cookie, err := portal_tests.AuthenticateSuite(ctx, owner.Email, srv, server.XSRF, server.Sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Set(common.ParamCSRFToken, server.XSRF.Token(strconv.Itoa(int(owner.ID))))
+	form.Set(common.ParamUser, server.IDHasher.Encrypt(int(newOwner.ID)))
+
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/org/%s/transfer", server.IDHasher.Encrypt(int(org.ID))), strings.NewReader(form.Encode()))
+	req.AddCookie(cookie)
+	req.Header.Set(common.HeaderContentType, common.ContentTypeURLEncoded)
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("Expected redirect, got %d", w.Code)
+	}
+
+	location, _ := w.Result().Location()
+	if path := location.String(); path != "/" {
+		t.Fatalf("Expected successful redirect, got %s", path)
+	}
+
+	newOwnerOrgs, err := store.Impl().RetrieveUserOrganizations(ctx, newOwner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, o := range newOwnerOrgs {
+		if o.Organization.ID == org.ID && o.Level == dbgen.AccessLevelOwner {
+			return
+		}
+	}
+
+	t.Fatal("Expected destination user to become owner at exact forms limit")
 }
 
 func TestOrgEndpointsInvalidPathArg(t *testing.T) {

--- a/web/layouts/form/integrations.html
+++ b/web/layouts/form/integrations.html
@@ -71,7 +71,7 @@
 {{ `<script defer src="https:` }}{{$.Ctx.CDN}}{{ `/widget/js/privatecaptcha.js"></script>` }}
 
 {{ `<!-- Use this instead of your existing form -->` }}
-{{ `<form method="POST" action="https:`}}{{$.Ctx.API}}{{ .Params.Form.ExternalID }}{{ `">
+{{ `<form method="POST" action="https:`}}{{$.Ctx.API}}{{ `/form/` }}{{ .Params.Form.ExternalID }}{{ `">
   <!-- Existing form fields... -->
   <div class="private-captcha" data-sitekey="` }}{{ .Params.Sitekey }}{{ `"></div>
   <!-- <input type="submit" disabled /> -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization transfers now validate subscription-based limits for the destination owner. The system prevents transfers when the destination user's property or form limits would be exceeded, redirecting to payment options as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->