### PR TITLE
Fix IPv6 translation SSFR

### DIFF
--- a/pkg/api/form_url_verifier.go
+++ b/pkg/api/form_url_verifier.go
@@ -19,6 +19,7 @@ import (
 var (
 	errUnsafeFormURL         = errors.New("unsafe form URL")
 	formNAT64Prefix          = netip.MustParsePrefix("64:ff9b::/96")
+	formNAT64LocalUsePrefix  = netip.MustParsePrefix("64:ff9b:1::/48")
 	form6To4Prefix           = netip.MustParsePrefix("2002::/16")
 	formIPv4CompatiblePrefix = netip.MustParsePrefix("::/96")
 )
@@ -36,7 +37,29 @@ type FormURLSafetyChecker interface {
 	IsSafeFormHostname(host string) bool
 }
 
-type FormURLSafetyCheckerImpl struct{}
+type FormURLSafetyCheckerImpl struct {
+	nat64Prefixes []netip.Prefix
+}
+
+func NewFormURLSafetyChecker(nat64Prefixes ...netip.Prefix) (*FormURLSafetyCheckerImpl, error) {
+	for _, prefix := range nat64Prefixes {
+		if !prefix.IsValid() || !prefix.Addr().Is6() || prefix != prefix.Masked() {
+			return nil, fmt.Errorf("invalid RFC 6052 NAT64 prefix: %s", prefix)
+		}
+		if prefix.Addr().As16()[8] != 0 {
+			return nil, fmt.Errorf("RFC 6052 NAT64 prefix has nonzero u octet: %s", prefix)
+		}
+		switch prefix.Bits() {
+		case 32, 40, 48, 56, 64, 96:
+		default:
+			return nil, fmt.Errorf("unsupported RFC 6052 NAT64 prefix length: %s", prefix)
+		}
+	}
+
+	return &FormURLSafetyCheckerImpl{
+		nat64Prefixes: append([]netip.Prefix(nil), nat64Prefixes...),
+	}, nil
+}
 
 func (*FormURLSafetyCheckerImpl) IsSafeFormHostname(host string) bool {
 	return (host != "localhost") && !strings.HasSuffix(host, ".localhost") && !strings.HasSuffix(host, ".local")
@@ -52,14 +75,50 @@ func isSafeFormIP(ip netip.Addr) bool {
 		!ip.IsUnspecified()
 }
 
-func extractEmbeddedIPv4(ip netip.Addr) (netip.Addr, bool) {
+func extractRFC6052IPv4(bytes [16]byte, prefixBits int) netip.Addr {
+	switch prefixBits {
+	case 32:
+		return netip.AddrFrom4([4]byte{bytes[4], bytes[5], bytes[6], bytes[7]})
+	case 40:
+		return netip.AddrFrom4([4]byte{bytes[5], bytes[6], bytes[7], bytes[9]})
+	case 48:
+		return netip.AddrFrom4([4]byte{bytes[6], bytes[7], bytes[9], bytes[10]})
+	case 56:
+		return netip.AddrFrom4([4]byte{bytes[7], bytes[9], bytes[10], bytes[11]})
+	case 64:
+		return netip.AddrFrom4([4]byte{bytes[9], bytes[10], bytes[11], bytes[12]})
+	case 96:
+		return netip.AddrFrom4([4]byte{bytes[12], bytes[13], bytes[14], bytes[15]})
+	default:
+		return netip.Addr{}
+	}
+}
+
+func extractEmbeddedIPv4(ip netip.Addr, nat64Prefixes []netip.Prefix) (netip.Addr, bool) {
 	if !ip.Is6() {
 		return netip.Addr{}, false
 	}
 
+	nat64Prefix := netip.Prefix{}
+	if formNAT64Prefix.Contains(ip) {
+		nat64Prefix = formNAT64Prefix
+	}
+	for _, prefix := range nat64Prefixes {
+		if prefix.Contains(ip) && (!nat64Prefix.IsValid() || prefix.Bits() > nat64Prefix.Bits()) {
+			nat64Prefix = prefix
+		}
+	}
+
 	bytes := ip.As16()
+	if nat64Prefix.IsValid() {
+		if bytes[8] != 0 {
+			return netip.Addr{}, true
+		}
+		return extractRFC6052IPv4(bytes, nat64Prefix.Bits()), true
+	}
+
 	switch {
-	case formNAT64Prefix.Contains(ip), formIPv4CompatiblePrefix.Contains(ip):
+	case formIPv4CompatiblePrefix.Contains(ip):
 		return netip.AddrFrom4([4]byte{bytes[12], bytes[13], bytes[14], bytes[15]}), true
 	case form6To4Prefix.Contains(ip):
 		return netip.AddrFrom4([4]byte{bytes[2], bytes[3], bytes[4], bytes[5]}), true
@@ -68,13 +127,20 @@ func extractEmbeddedIPv4(ip netip.Addr) (netip.Addr, bool) {
 	}
 }
 
-func (*FormURLSafetyCheckerImpl) IsSafeFormIP(ip netip.Addr) bool {
+func (c *FormURLSafetyCheckerImpl) IsSafeFormIP(ip netip.Addr) bool {
+	if c == nil {
+		return false
+	}
+
 	ip = ip.Unmap()
 	if !isSafeFormIP(ip) {
 		return false
 	}
-	if embedded, ok := extractEmbeddedIPv4(ip); ok {
+	if embedded, ok := extractEmbeddedIPv4(ip, c.nat64Prefixes); ok {
 		return isSafeFormIP(embedded)
+	}
+	if formNAT64LocalUsePrefix.Contains(ip) {
+		return false
 	}
 
 	return true

--- a/pkg/api/form_url_verifier.go
+++ b/pkg/api/form_url_verifier.go
@@ -17,7 +17,10 @@ import (
 )
 
 var (
-	errUnsafeFormURL = errors.New("unsafe form URL")
+	errUnsafeFormURL         = errors.New("unsafe form URL")
+	formNAT64Prefix          = netip.MustParsePrefix("64:ff9b::/96")
+	form6To4Prefix           = netip.MustParsePrefix("2002::/16")
+	formIPv4CompatiblePrefix = netip.MustParsePrefix("::/96")
 )
 
 const (
@@ -39,8 +42,7 @@ func (*FormURLSafetyCheckerImpl) IsSafeFormHostname(host string) bool {
 	return (host != "localhost") && !strings.HasSuffix(host, ".localhost") && !strings.HasSuffix(host, ".local")
 }
 
-func (*FormURLSafetyCheckerImpl) IsSafeFormIP(ip netip.Addr) bool {
-	ip = ip.Unmap()
+func isSafeFormIP(ip netip.Addr) bool {
 	return ip.IsValid() &&
 		ip.IsGlobalUnicast() &&
 		!ip.IsPrivate() &&
@@ -48,6 +50,34 @@ func (*FormURLSafetyCheckerImpl) IsSafeFormIP(ip netip.Addr) bool {
 		!ip.IsLinkLocalUnicast() &&
 		!ip.IsMulticast() &&
 		!ip.IsUnspecified()
+}
+
+func extractEmbeddedIPv4(ip netip.Addr) (netip.Addr, bool) {
+	if !ip.Is6() {
+		return netip.Addr{}, false
+	}
+
+	bytes := ip.As16()
+	switch {
+	case formNAT64Prefix.Contains(ip), formIPv4CompatiblePrefix.Contains(ip):
+		return netip.AddrFrom4([4]byte{bytes[12], bytes[13], bytes[14], bytes[15]}), true
+	case form6To4Prefix.Contains(ip):
+		return netip.AddrFrom4([4]byte{bytes[2], bytes[3], bytes[4], bytes[5]}), true
+	default:
+		return netip.Addr{}, false
+	}
+}
+
+func (*FormURLSafetyCheckerImpl) IsSafeFormIP(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	if !isSafeFormIP(ip) {
+		return false
+	}
+	if embedded, ok := extractEmbeddedIPv4(ip); ok {
+		return isSafeFormIP(embedded)
+	}
+
+	return true
 }
 
 type FormURLVerifierImpl struct {

--- a/pkg/api/form_url_verifier_test.go
+++ b/pkg/api/form_url_verifier_test.go
@@ -206,7 +206,104 @@ func TestFormURLSafetyCheckerImplMethods(t *testing.T) {
 	if checker.IsSafeFormIP(netip.MustParseAddr("127.0.0.1")) {
 		t.Fatal("expected loopback IP to be unsafe")
 	}
+	if checker.IsSafeFormIP(netip.MustParseAddr("::1")) {
+		t.Fatal("expected IPv6 loopback IP to be unsafe")
+	}
+	if checker.IsSafeFormIP(netip.MustParseAddr("::ffff:127.0.0.1")) {
+		t.Fatal("expected IPv4-mapped loopback IP to be unsafe")
+	}
+	if checker.IsSafeFormIP(netip.MustParseAddr("::ffff:10.0.0.1")) {
+		t.Fatal("expected IPv4-mapped private IP to be unsafe")
+	}
+	if checker.IsSafeFormIP(netip.Addr{}) {
+		t.Fatal("expected invalid IP to be unsafe")
+	}
 	if !checker.IsSafeFormIP(netip.MustParseAddr("93.184.216.34")) {
 		t.Fatal("expected public IP to be safe")
+	}
+	if !checker.IsSafeFormIP(netip.MustParseAddr("::ffff:93.184.216.34")) {
+		t.Fatal("expected IPv4-mapped public IP to be safe")
+	}
+}
+
+func TestFormURLVerifierRejectsDNSResolvedIPv6Loopback(t *testing.T) {
+	resolver := &stubFormURLResolver{
+		addresses: map[string][]string{"example.com": {"::1"}},
+		calls:     map[string]int{},
+	}
+	verifier := newTestFormURLVerifierEx(t, &FormURLSafetyCheckerImpl{}, resolver)
+
+	if err := verifier.VerifyURL(context.Background(), "https://example.com/form"); !errors.Is(err, errUnsafeFormURL) {
+		t.Fatalf("expected DNS-resolved IPv6 loopback to be rejected as unsafe, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := verifier.DialContext(ctx, "tcp", "example.com:443"); !errors.Is(err, errUnsafeFormURL) {
+		t.Fatalf("expected DNS-resolved IPv6 loopback dial to be rejected as unsafe, got %v", err)
+	}
+}
+
+func TestFormURLSafetyCheckerRejectsUnsafeIPv6TransitionAddresses(t *testing.T) {
+	checker := &FormURLSafetyCheckerImpl{}
+
+	for _, tc := range []struct {
+		name string
+		ip   string
+	}{
+		{name: "NAT64 private", ip: "64:ff9b::10.0.0.1"},
+		{name: "NAT64 loopback", ip: "64:ff9b::127.0.0.1"},
+		{name: "NAT64 link local", ip: "64:ff9b::169.254.169.254"},
+		{name: "6to4 private", ip: "2002:0a00:0001::"},
+		{name: "6to4 loopback", ip: "2002:7f00:0001::"},
+		{name: "6to4 link local", ip: "2002:a9fe:a9fe::"},
+		{name: "IPv4 compatible private", ip: "::10.0.0.1"},
+		{name: "IPv4 compatible loopback", ip: "::127.0.0.1"},
+		{name: "IPv4 compatible link local", ip: "::169.254.169.254"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if checker.IsSafeFormIP(netip.MustParseAddr(tc.ip)) {
+				t.Fatalf("expected IPv6 transition address %s to be unsafe", tc.ip)
+			}
+		})
+	}
+}
+
+func TestFormURLSafetyCheckerAllowsPublicIPv6TransitionAddresses(t *testing.T) {
+	checker := &FormURLSafetyCheckerImpl{}
+
+	for _, ip := range []string{
+		"64:ff9b::93.184.216.34",
+		"2002:5db8:d822::",
+		"::93.184.216.34",
+	} {
+		t.Run(ip, func(t *testing.T) {
+			if !checker.IsSafeFormIP(netip.MustParseAddr(ip)) {
+				t.Fatalf("expected IPv6 transition address %s to be safe", ip)
+			}
+		})
+	}
+}
+
+func TestFormURLDialContextRejectsUnsafeIPv6TransitionAddresses(t *testing.T) {
+	for _, ip := range []string{
+		"64:ff9b::10.0.0.1",
+		"2002:0a00:0001::",
+		"::10.0.0.1",
+	} {
+		t.Run(ip, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			resolver := &stubFormURLResolver{
+				addresses: map[string][]string{"example.com": {ip}},
+				calls:     map[string]int{},
+			}
+			verifier := newTestFormURLVerifierEx(t, &FormURLSafetyCheckerImpl{}, resolver)
+
+			_, err := verifier.DialContext(ctx, "tcp", "example.com:443")
+			if !errors.Is(err, errUnsafeFormURL) {
+				t.Fatalf("expected IPv6 transition address %s to be rejected as unsafe, got %v", ip, err)
+			}
+		})
 	}
 }

--- a/pkg/api/form_url_verifier_test.go
+++ b/pkg/api/form_url_verifier_test.go
@@ -224,6 +224,10 @@ func TestFormURLSafetyCheckerImplMethods(t *testing.T) {
 	if !checker.IsSafeFormIP(netip.MustParseAddr("::ffff:93.184.216.34")) {
 		t.Fatal("expected IPv4-mapped public IP to be safe")
 	}
+	var nilChecker *FormURLSafetyCheckerImpl
+	if nilChecker.IsSafeFormIP(netip.MustParseAddr("93.184.216.34")) {
+		t.Fatal("expected nil checker to fail closed")
+	}
 }
 
 func TestFormURLVerifierRejectsDNSResolvedIPv6Loopback(t *testing.T) {
@@ -254,6 +258,8 @@ func TestFormURLSafetyCheckerRejectsUnsafeIPv6TransitionAddresses(t *testing.T) 
 		{name: "NAT64 private", ip: "64:ff9b::10.0.0.1"},
 		{name: "NAT64 loopback", ip: "64:ff9b::127.0.0.1"},
 		{name: "NAT64 link local", ip: "64:ff9b::169.254.169.254"},
+		{name: "NAT64 local use unconfigured private", ip: "64:ff9b:1:a00:0:100::"},
+		{name: "NAT64 local use unconfigured public", ip: "64:ff9b:1:5db8:d8:2200::"},
 		{name: "6to4 private", ip: "2002:0a00:0001::"},
 		{name: "6to4 loopback", ip: "2002:7f00:0001::"},
 		{name: "6to4 link local", ip: "2002:a9fe:a9fe::"},
@@ -280,6 +286,92 @@ func TestFormURLSafetyCheckerAllowsPublicIPv6TransitionAddresses(t *testing.T) {
 		t.Run(ip, func(t *testing.T) {
 			if !checker.IsSafeFormIP(netip.MustParseAddr(ip)) {
 				t.Fatalf("expected IPv6 transition address %s to be safe", ip)
+			}
+		})
+	}
+}
+
+func TestFormURLSafetyCheckerUsesConfiguredNAT64Prefix(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		prefix    string
+		privateIP string
+		publicIP  string
+	}{
+		{name: "32 bit prefix", prefix: "2001:db8::/32", privateIP: "2001:db8:a00:1::", publicIP: "2001:db8:5db8:d822::"},
+		{name: "40 bit prefix", prefix: "2001:db8:100::/40", privateIP: "2001:db8:10a:0:1::", publicIP: "2001:db8:15d:b8d8:22::"},
+		{name: "48 bit prefix", prefix: "2001:db8:122::/48", privateIP: "2001:db8:122:a00:0:100::", publicIP: "2001:db8:122:5db8:d8:2200::"},
+		{name: "48 bit local prefix", prefix: "64:ff9b:1::/48", privateIP: "64:ff9b:1:a00:0:100::", publicIP: "64:ff9b:1:5db8:d8:2200::"},
+		{name: "56 bit prefix", prefix: "2001:db8:122:300::/56", privateIP: "2001:db8:122:30a:0:1::", publicIP: "2001:db8:122:35d:b8:d822::"},
+		{name: "64 bit prefix", prefix: "2001:db8:122:344::/64", privateIP: "2001:db8:122:344:a:0:100::", publicIP: "2001:db8:122:344:5d:b8d8:2200::"},
+		{name: "96 bit local prefix", prefix: "64:ff9b:1:fffe::/96", privateIP: "64:ff9b:1:fffe::10.0.0.1", publicIP: "64:ff9b:1:fffe::93.184.216.34"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			checker, err := NewFormURLSafetyChecker(netip.MustParsePrefix(tc.prefix))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if checker.IsSafeFormIP(netip.MustParseAddr(tc.privateIP)) {
+				t.Fatal("expected configured NAT64 prefix with private embedded IPv4 to be unsafe")
+			}
+			if !checker.IsSafeFormIP(netip.MustParseAddr(tc.publicIP)) {
+				t.Fatal("expected configured NAT64 prefix with public embedded IPv4 to be safe")
+			}
+		})
+	}
+
+	checker, err := NewFormURLSafetyChecker(
+		netip.MustParsePrefix("64:ff9b:1::/48"),
+		netip.MustParsePrefix("64:ff9b:1:5db8:d8:2200::/96"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checker.IsSafeFormIP(netip.MustParseAddr("64:ff9b:1:5db8:d8:2200:a00:1")) {
+		t.Fatal("expected the most-specific NAT64 prefix to classify the embedded private IPv4")
+	}
+}
+
+func TestFormURLSafetyCheckerRejectsInvalidNAT64Prefixes(t *testing.T) {
+	for _, prefix := range []netip.Prefix{
+		{},
+		netip.MustParsePrefix("192.0.2.0/24"),
+		netip.MustParsePrefix("2001:db8:1::/65"),
+		netip.MustParsePrefix("2001:db8:1::1/96"),
+		netip.MustParsePrefix("2001:db8:1:2:100::/96"),
+	} {
+		if _, err := NewFormURLSafetyChecker(prefix); err == nil {
+			t.Fatalf("expected NAT64 prefix %s to be rejected", prefix)
+		}
+	}
+}
+
+func TestFormURLSafetyCheckerRejectsNonzeroNAT64UOctet(t *testing.T) {
+	checker, err := NewFormURLSafetyChecker(netip.MustParsePrefix("64:ff9b:1::/48"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checker.IsSafeFormIP(netip.MustParseAddr("64:ff9b:1:5db8:ffd8:2200::")) {
+		t.Fatal("expected NAT64 address with nonzero u octet to be unsafe")
+	}
+}
+
+func TestExtractRFC6052IPv4(t *testing.T) {
+	for _, tc := range []struct {
+		prefixBits int
+		ip         string
+	}{
+		{prefixBits: 32, ip: "2001:db8:a00:1::"},
+		{prefixBits: 40, ip: "2001:db8:10a:0:1::"},
+		{prefixBits: 48, ip: "2001:db8:122:a00:0:100::"},
+		{prefixBits: 56, ip: "2001:db8:122:30a:0:1::"},
+		{prefixBits: 64, ip: "2001:db8:122:344:a:0:100::"},
+		{prefixBits: 96, ip: "2001:db8:122:344::10.0.0.1"},
+	} {
+		t.Run(tc.ip, func(t *testing.T) {
+			got := extractRFC6052IPv4(netip.MustParseAddr(tc.ip).As16(), tc.prefixBits)
+			if want := netip.MustParseAddr("10.0.0.1"); got != want {
+				t.Fatalf("expected embedded IPv4 %s, got %s", want, got)
 			}
 		})
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable NAT64 prefix support for form URL safety checks.
  - Added validation for RFC 6052 IPv4 extraction from IPv6 addresses.

- **Bug Fixes**
  - Improved detection of unsafe loopback, private, reserved, and invalid addresses across NAT64, 6to4, IPv4-compatible, and IPv4-mapped IPv6 formats.
  - Prevented unsafe destinations reached through DNS resolution or dialing.
  - Continued allowing valid public IPv6 transition addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->