### PR TITLE
Don't allow changing email during org invite

### DIFF
--- a/pkg/portal/login.go
+++ b/pkg/portal/login.go
@@ -32,12 +32,13 @@ var (
 type loginRenderContext struct {
 	CsrfRenderContext
 	CaptchaRenderContext
-	Email       string
-	EmailError  string
-	CodeError   string
-	NameError   string
-	CanRegister bool
-	IsRegister  bool
+	Email         string
+	EmailError    string
+	CodeError     string
+	NameError     string
+	CanRegister   bool
+	IsRegister    bool
+	EmailReadonly bool
 }
 
 type portalPropertyOwnerSource struct {

--- a/pkg/portal/org_enterprise.go
+++ b/pkg/portal/org_enterprise.go
@@ -765,6 +765,7 @@ func (s *Server) getOrgInviteRegister(w http.ResponseWriter, r *http.Request) (*
 		}
 
 		model.Email = invite.Email.String
+		model.EmailReadonly = true
 
 		// Store invite ID in session so we can link it after registration
 		sess := s.Sessions.SessionStart(w, r)

--- a/pkg/portal/register.go
+++ b/pkg/portal/register.go
@@ -3,6 +3,7 @@ package portal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -185,6 +186,19 @@ func (s *Server) postRegister(w http.ResponseWriter, r *http.Request) {
 	code := twoFactorCode(ctx)
 	location := r.Header.Get(s.CountryCodeHeader.Value())
 
+	sess := s.Sessions.SessionStart(w, r)
+
+	// Validate email matches invited email if this is an invite registration
+	if inviteID, ok := sess.Get(ctx, session.KeyOrgInviteID).(int32); ok && inviteID > 0 {
+		if invite, err := s.Store.Impl().GetCachedOrgInviteByID(ctx, inviteID); err == nil {
+			if strings.ToLower(email) != strings.ToLower(invite.Email.String) {
+				data.EmailError = fmt.Sprintf("You must register with %s to accept this organization invitation.", invite.Email.String)
+				s.render(w, r, registerContentsTemplate, data, false /*new*/)
+				return
+			}
+		}
+	}
+
 	if err := s.Mailer.SendTwoFactor(ctx, email, code, r.UserAgent(), location, true); err != nil {
 		slog.ErrorContext(ctx, "Failed to send email message", common.ErrAttr(err))
 		data.EmailError = "Failed to send a confirmation email. Please try again."
@@ -192,7 +206,6 @@ func (s *Server) postRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess := s.Sessions.SessionStart(w, r)
 	ctx = context.WithValue(ctx, common.SessionIDContextKey, sess.ID())
 
 	_ = sess.Set(ctx, session.KeyLoginStep, loginStepSignUpVerify)

--- a/pkg/portal/register.go
+++ b/pkg/portal/register.go
@@ -191,7 +191,7 @@ func (s *Server) postRegister(w http.ResponseWriter, r *http.Request) {
 	// Validate email matches invited email if this is an invite registration
 	if inviteID, ok := sess.Get(ctx, session.KeyOrgInviteID).(int32); ok && inviteID > 0 {
 		if invite, err := s.Store.Impl().GetCachedOrgInviteByID(ctx, inviteID); err == nil {
-			if strings.ToLower(email) != strings.ToLower(invite.Email.String) {
+			if !strings.EqualFold(email, invite.Email.String) {
 				data.EmailError = fmt.Sprintf("You must register with %s to accept this organization invitation.", invite.Email.String)
 				s.render(w, r, registerContentsTemplate, data, false /*new*/)
 				return

--- a/pkg/portal/viewportal.go
+++ b/pkg/portal/viewportal.go
@@ -720,7 +720,7 @@ func (s *Server) BuildViewPortalPages() []ViewPortalPage {
 			ModelFunc: func(_ AlertRenderContext) interface{} {
 				return &loginRenderContext{
 					CsrfRenderContext: token, CaptchaRenderContext: captchaCtx,
-					Email: "invited@example.com", CanRegister: true, IsRegister: true,
+					Email: "invited@example.com", CanRegister: true, IsRegister: true, EmailReadonly: true,
 				}
 			},
 		},

--- a/web/layouts/login/register-form.html
+++ b/web/layouts/login/register-form.html
@@ -18,7 +18,7 @@
             {{- if .Params.EmailError -}}
             {{template "info-icon-red.html" .}}
             {{- end -}}
-            <input type="email" id="emailInput" name="{{ .Const.Email }}" placeholder="Email address" {{ if .Params.Email }}value="{{.Params.Email}}"{{end}} class="w-full pc-form-input-base {{ if .Params.EmailError }}pc-form-input-error{{ else }}pc-form-input-normal{{ end }}" required />
+            <input type="email" id="emailInput" name="{{ .Const.Email }}" placeholder="Email address" {{ if .Params.Email }}value="{{.Params.Email}}"{{end}} {{ if .Params.EmailReadonly }} readonly{{end}} class="w-full pc-form-input-base {{ if .Params.EmailError }}pc-form-input-error{{ else }}pc-form-input-normal{{ end }} {{ if .Params.EmailReadonly }} pc-form-input-disabled{{end}}" required />
         </div>
         {{- if .Params.EmailError -}}
         <p class="pc-form-error-text">{{ .Params.EmailError }}</p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization invite registration now pre-fills the invited email address and prevents it from being edited.
  - Read-only email fields display appropriate disabled styling.

- **Bug Fixes**
  - Registration checks that the submitted email matches the organization invite, regardless of letter casing.
  - Mismatched invite emails show a validation error and prevent confirmation emails from being sent.
  - Registration flow now handles session setup more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->