### PR TITLE
Add difficulty rule for detecting browser version drift

### DIFF
--- a/cmd/server/browser_versions_ee.go
+++ b/cmd/server/browser_versions_ee.go
@@ -1,0 +1,24 @@
+//go:build enterprise
+
+package main
+
+import (
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/common"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/db"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/maintenance"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/rules"
+)
+
+func newBrowserVersionJobs(store db.Implementor, compiler *rules.RulesCompiler) (common.PeriodicJob, common.PeriodicJob) {
+	fetchTrigger := make(chan struct{}, 1)
+	refreshTrigger := make(chan struct{}, 1)
+	fetchJob := maintenance.NewFetchBrowserVersionsJob(store)
+	fetchJob.TriggerCh = fetchTrigger
+	fetchJob.RefreshTrigger = refreshTrigger
+	refreshJob := maintenance.NewRefreshBrowserVersionsJob(store, compiler.BrowserVersions())
+	refreshJob.TriggerCh = refreshTrigger
+
+	fetchTrigger <- struct{}{}
+	refreshTrigger <- struct{}{}
+	return fetchJob, refreshJob
+}

--- a/cmd/server/browser_versions_not_ee.go
+++ b/cmd/server/browser_versions_not_ee.go
@@ -1,0 +1,13 @@
+//go:build !enterprise
+
+package main
+
+import (
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/common"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/db"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/rules"
+)
+
+func newBrowserVersionJobs(db.Implementor, *rules.RulesCompiler) (common.PeriodicJob, common.PeriodicJob) {
+	return common.StubPeriodicJob("fetch_browser_versions_job"), common.StubPeriodicJob("refresh_browser_versions_job")
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -419,6 +419,9 @@ func run(ctx context.Context, cfg common.ConfigStore, stderr io.Writer, listener
 
 	jobConcurrency := config.AsInt(cfg.Get(common.MaintenanceJobConcurrencyKey), 2)
 	jobs := maintenance.NewJobs(businessDB, jobConcurrency)
+	fetchBrowserVersions, refreshBrowserVersions := newBrowserVersionJobs(businessDB, rulesCompiler)
+	jobs.AddLocked(24*time.Hour, fetchBrowserVersions)
+	jobs.Add(refreshBrowserVersions)
 
 	jobs.Spawn(healthCheck)
 	// start maintenance jobs

--- a/pkg/api/jobs_test.go
+++ b/pkg/api/jobs_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -15,11 +17,93 @@ import (
 	db_tests "github.com/PrivateCaptcha/PrivateCaptcha/pkg/db/tests"
 	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/email"
 	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/maintenance"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/rules"
 	"github.com/rs/xid"
 )
 
 type TestJob struct {
 	count int32
+}
+
+func TestBrowserVersionPipeline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := common.TraceContext(t.Context(), t.Name())
+	compiler, ok := server.Auth.RulesCompiler.(*rules.RulesCompiler)
+	if !ok {
+		t.Fatalf("API rules compiler type = %T, want *rules.RulesCompiler", server.Auth.RulesCompiler)
+	}
+	queries := dbgen.New(store.Pool)
+	t.Cleanup(func() {
+		compiler.BrowserVersions().Replace(nil)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := queries.DeleteCachedByKey(cleanupCtx, maintenance.BrowserVersionsCacheKey); err != nil {
+			t.Errorf("delete browser versions cache: %v", err)
+		}
+	})
+
+	records := make([]maintenance.BrowserVersionRecord, 0, 9)
+	for _, browser := range []string{rules.BrowserChrome, rules.BrowserFirefox} {
+		for _, platform := range []string{rules.PlatformWindows, rules.PlatformMacOS, rules.PlatformLinux, rules.PlatformAndroid} {
+			records = append(records, maintenance.BrowserVersionRecord{Browser: browser, Platform: platform, Version: "152.0"})
+		}
+	}
+	records = append(records, maintenance.BrowserVersionRecord{Browser: rules.BrowserChrome, Platform: rules.PlatformIOS, Version: "152.0"})
+	data, err := json.Marshal(maintenance.BrowserVersionsSnapshot{Versions: records})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Impl().StoreInCache(ctx, maintenance.BrowserVersionsCacheKey, data, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	refreshJob := maintenance.NewRefreshBrowserVersionsJob(store, compiler.BrowserVersions())
+	if err := refreshJob.RunOnce(ctx, refreshJob.NewParams()); err != nil {
+		t.Fatal(err)
+	}
+	key := rules.BrowserVersionKey{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows}
+	if major, ok := compiler.BrowserVersions().Major(key); !ok || major != 152 {
+		t.Fatalf("compiler browser major = %d, %v, want 152, true", major, ok)
+	}
+
+	user, org, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name(), testPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rule, _, err := store.Impl().CreateDifficultyRule(ctx, user, &dbgen.CreateDifficultyRuleParams{
+		Name:              t.Name(),
+		OrgID:             db.Int(org.ID),
+		CreatorID:         db.Int(user.ID),
+		Enabled:           true,
+		ConditionProperty: dbgen.RuleConditionPropertyBrowserVersion,
+		ConditionOperator: dbgen.RuleConditionOperatorMore,
+		ConditionValueInt: db.Int(2),
+		ActionProperty:    dbgen.RuleActionPropertyHTTPRequest,
+		ActionValue:       1,
+		Terminal:          true,
+		Column15:          db.RulePositionStep,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Cache.Delete(ctx, db.DifficultyRuleCacheKey(rule.ID))
+	rule, err = store.Impl().RetrieveDifficultyRule(ctx, rule.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rule.ConditionValueInt.Valid || rule.ConditionValueInt.Int32 != 2 {
+		t.Fatalf("persisted browser version threshold = %+v, want 2", rule.ConditionValueInt)
+	}
+	compiled := compiler.Compile(ctx, []*dbgen.DifficultyRule{rule})
+
+	request := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	request.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36")
+	if !compiled.IsRequestBlocked(rules.NewRequestInfo(request, "")) {
+		t.Fatal("browser beyond the threshold was not blocked")
+	}
 }
 
 var _ common.PeriodicJob = (*TestJob)(nil)

--- a/pkg/common/job.go
+++ b/pkg/common/job.go
@@ -31,6 +31,18 @@ type PeriodicJob interface {
 	Trigger() <-chan struct{}
 }
 
+type StubPeriodicJob string
+
+var _ PeriodicJob = StubPeriodicJob("")
+
+func (j StubPeriodicJob) Name() string                     { return string(j) }
+func (StubPeriodicJob) Interval() time.Duration            { return time.Hour }
+func (StubPeriodicJob) Timeout() time.Duration             { return 0 }
+func (StubPeriodicJob) Jitter() time.Duration              { return 1 }
+func (StubPeriodicJob) Trigger() <-chan struct{}           { return nil }
+func (StubPeriodicJob) NewParams() any                     { return struct{}{} }
+func (StubPeriodicJob) RunOnce(context.Context, any) error { return nil }
+
 type StubOneOffJob struct{}
 
 var _ OneOffJob = (*StubOneOffJob)(nil)

--- a/pkg/common/statuscode.go
+++ b/pkg/common/statuscode.go
@@ -80,6 +80,7 @@ const (
 	StatusRuleHTTPHeaderNameRequired        StatusCode = 1425
 	StatusRuleHTTPHeaderNameInvalid         StatusCode = 1426
 	StatusRuleNameInvalidCharsError         StatusCode = 1427
+	StatusRuleConditionValueInvalid         StatusCode = 1428
 	// forms errors
 	StatusFormNameEmptyError          StatusCode = 1500
 	StatusFormNameTooLongError        StatusCode = 1501
@@ -219,6 +220,8 @@ func (sc StatusCode) String() string {
 		return "HTTP header name is not valid."
 	case StatusRuleNameInvalidCharsError:
 		return "Rule name can only contain letters, numbers, spaces, hyphens, and dots."
+	case StatusRuleConditionValueInvalid:
+		return "Condition value is invalid."
 	default:
 		if s, ok := extraStatusCodeStrings[sc]; ok {
 			return s

--- a/pkg/common/statuscode_test.go
+++ b/pkg/common/statuscode_test.go
@@ -63,6 +63,7 @@ func TestStatusCodeString(t *testing.T) {
 		StatusRuleHTTPHeaderNameRequired,
 		StatusRuleHTTPHeaderNameInvalid,
 		StatusRuleNameInvalidCharsError,
+		StatusRuleConditionValueInvalid,
 		StatusOrgRulesLimitError,
 		StatusOrgRulesSubscriptionRequired,
 		StatusFormNameEmptyError,

--- a/pkg/db/generated/models.go
+++ b/pkg/db/generated/models.go
@@ -331,6 +331,7 @@ const (
 	RuleConditionOperatorEmpty    RuleConditionOperator = "empty"
 	RuleConditionOperatorIn       RuleConditionOperator = "in"
 	RuleConditionOperatorBot      RuleConditionOperator = "bot"
+	RuleConditionOperatorMore     RuleConditionOperator = "more"
 )
 
 func (e *RuleConditionOperator) Scan(src interface{}) error {
@@ -377,6 +378,7 @@ const (
 	RuleConditionPropertyDomain         RuleConditionProperty = "domain"
 	RuleConditionPropertyHTTPHeaderName RuleConditionProperty = "http_header_name"
 	RuleConditionPropertyAlways         RuleConditionProperty = "always"
+	RuleConditionPropertyBrowserVersion RuleConditionProperty = "browser_version"
 )
 
 func (e *RuleConditionProperty) Scan(src interface{}) error {

--- a/pkg/db/migrations/postgres/000137_add_browser_version_rule.down.sql
+++ b/pkg/db/migrations/postgres/000137_add_browser_version_rule.down.sql
@@ -1,0 +1,2 @@
+-- PostgreSQL does not support removing values from enum types.
+-- The 'browser_version' and 'more' values cannot be rolled back automatically.

--- a/pkg/db/migrations/postgres/000137_add_browser_version_rule.up.sql
+++ b/pkg/db/migrations/postgres/000137_add_browser_version_rule.up.sql
@@ -1,0 +1,2 @@
+ALTER TYPE backend.rule_condition_property ADD VALUE IF NOT EXISTS 'browser_version';
+ALTER TYPE backend.rule_condition_operator ADD VALUE IF NOT EXISTS 'more';

--- a/pkg/db/sqlc.yaml
+++ b/pkg/db/sqlc.yaml
@@ -80,6 +80,7 @@ sql:
           backend_rule_condition_property_domain: RuleConditionPropertyDomain
           backend_rule_condition_property_http_header_name: RuleConditionPropertyHTTPHeaderName
           backend_rule_condition_property_always: RuleConditionPropertyAlways
+          backend_rule_condition_property_browser_version: RuleConditionPropertyBrowserVersion
           backend_rule_condition_operator: RuleConditionOperator
           backend_rule_condition_operator_equals: RuleConditionOperatorEquals
           backend_rule_condition_operator_contains: RuleConditionOperatorContains
@@ -87,6 +88,7 @@ sql:
           backend_rule_condition_operator_empty: RuleConditionOperatorEmpty
           backend_rule_condition_operator_in: RuleConditionOperatorIn
           backend_rule_condition_operator_bot: RuleConditionOperatorBot
+          backend_rule_condition_operator_more: RuleConditionOperatorMore
           backend_rule_action_property: RuleActionProperty
           backend_rule_action_property_difficulty_level_percent: RuleActionPropertyDifficultyLevelPercent
           backend_rule_action_property_http_request: RuleActionPropertyHTTPRequest

--- a/pkg/maintenance/browser_versions.go
+++ b/pkg/maintenance/browser_versions.go
@@ -1,0 +1,564 @@
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/common"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/db"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/rules"
+	"github.com/jpillora/backoff"
+)
+
+const (
+	BrowserVersionsCacheKey = "browser_versions"
+
+	browserVersionsCacheTTL      = 7 * 24 * time.Hour
+	browserVersionsMaxBytes      = 64 * 1024
+	browserVersionsLogBytes      = 100
+	browserVersionAttempts       = 8
+	browserVersionMaxLength      = 64
+	browserVersionMaxParts       = 4
+	browserVersionMaxMajor       = 1000
+	browserVersionMaxJump        = 10
+	browserVersionMaxConcurrency = 2
+
+	chromePlatformWindows = "win"
+	chromePlatformMacOS   = "mac"
+	chromePlatformLinux   = "linux"
+	chromePlatformAndroid = "android"
+	chromePlatformIOS     = "ios"
+
+	defaultChromeVersionURL        = "https://versionhistory.googleapis.com/v1/chrome/platforms/{platform}/channels/stable/versions?pageSize=1&order_by=version%20desc"
+	defaultFirefoxVersionURL       = "https://product-details.mozilla.org/1.0/firefox_versions.json"
+	defaultFirefoxMobileVersionURL = "https://product-details.mozilla.org/1.0/mobile_versions.json"
+)
+
+var (
+	errBrowserVersionsRequest  = errors.New("browser version request error")
+	errBrowserVersionsResponse = errors.New("browser version response error")
+	errBrowserVersionsStorage  = errors.New("browser version storage error")
+)
+
+var supportedBrowserVersionKeys = map[rules.BrowserVersionKey]struct{}{
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows}:  {},
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformMacOS}:    {},
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformLinux}:    {},
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformAndroid}:  {},
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformIOS}:      {},
+	{Browser: rules.BrowserFirefox, Platform: rules.PlatformWindows}: {},
+	{Browser: rules.BrowserFirefox, Platform: rules.PlatformMacOS}:   {},
+	{Browser: rules.BrowserFirefox, Platform: rules.PlatformLinux}:   {},
+	{Browser: rules.BrowserFirefox, Platform: rules.PlatformAndroid}: {},
+}
+
+var legacyBrowserVersionKeys = map[rules.BrowserVersionKey]struct{}{
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows}:  {},
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformMacOS}:    {},
+	{Browser: rules.BrowserChrome, Platform: rules.PlatformLinux}:    {},
+	{Browser: rules.BrowserFirefox, Platform: rules.PlatformWindows}: {},
+	{Browser: rules.BrowserFirefox, Platform: rules.PlatformMacOS}:   {},
+	{Browser: rules.BrowserFirefox, Platform: rules.PlatformLinux}:   {},
+}
+
+type BrowserVersionRecord struct {
+	Browser  string `json:"browser"`
+	Platform string `json:"platform"`
+	Version  string `json:"version"`
+}
+
+type BrowserVersionsSnapshot struct {
+	Versions []BrowserVersionRecord `json:"versions"`
+}
+
+type browserVersionSource struct {
+	browser   string
+	platforms []string
+	fetch     func(context.Context) (string, error)
+}
+
+type browserVersionResult struct {
+	version string
+	err     error
+}
+
+type FetchBrowserVersionsJob struct {
+	Store             db.Implementor
+	Client            *http.Client
+	ChromeURLTemplate string
+	FirefoxURL        string
+	FirefoxMobileURL  string
+	TriggerCh         <-chan struct{}
+	RefreshTrigger    chan<- struct{}
+}
+
+type RefreshBrowserVersionsJob struct {
+	Store           db.Implementor
+	BrowserVersions *rules.BrowserVersions
+	TriggerCh       <-chan struct{}
+}
+
+var _ common.PeriodicJob = (*FetchBrowserVersionsJob)(nil)
+var _ common.PeriodicJob = (*RefreshBrowserVersionsJob)(nil)
+
+func NewFetchBrowserVersionsJob(store db.Implementor) *FetchBrowserVersionsJob {
+	return &FetchBrowserVersionsJob{
+		Store: store,
+		Client: &http.Client{
+			Timeout: 10 * time.Second,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		ChromeURLTemplate: defaultChromeVersionURL,
+		FirefoxURL:        defaultFirefoxVersionURL,
+		FirefoxMobileURL:  defaultFirefoxMobileVersionURL,
+	}
+}
+
+func NewRefreshBrowserVersionsJob(store db.Implementor, versions *rules.BrowserVersions) *RefreshBrowserVersionsJob {
+	return &RefreshBrowserVersionsJob{Store: store, BrowserVersions: versions}
+}
+
+func (j *FetchBrowserVersionsJob) Name() string             { return "fetch_browser_versions_job" }
+func (j *FetchBrowserVersionsJob) Interval() time.Duration  { return time.Hour }
+func (j *FetchBrowserVersionsJob) Timeout() time.Duration   { return time.Minute }
+func (j *FetchBrowserVersionsJob) Jitter() time.Duration    { return 10 * time.Minute }
+func (j *FetchBrowserVersionsJob) Trigger() <-chan struct{} { return j.TriggerCh }
+func (j *FetchBrowserVersionsJob) NewParams() any           { return struct{}{} }
+
+func (j *RefreshBrowserVersionsJob) Name() string             { return "refresh_browser_versions_job" }
+func (j *RefreshBrowserVersionsJob) Interval() time.Duration  { return 6 * time.Hour }
+func (j *RefreshBrowserVersionsJob) Timeout() time.Duration   { return time.Minute }
+func (j *RefreshBrowserVersionsJob) Jitter() time.Duration    { return 10 * time.Minute }
+func (j *RefreshBrowserVersionsJob) Trigger() <-chan struct{} { return j.TriggerCh }
+func (j *RefreshBrowserVersionsJob) NewParams() any           { return struct{}{} }
+
+func browserVersionResponsePrefix(data []byte) string {
+	return string(data[:min(len(data), browserVersionsLogBytes)])
+}
+
+func isRetriableBrowserVersionStatus(status int) bool {
+	return status >= http.StatusInternalServerError ||
+		status == http.StatusTooManyRequests ||
+		status == http.StatusRequestTimeout ||
+		status == http.StatusTooEarly
+}
+
+func doFetchBrowserVersionData(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	if client == nil || url == "" {
+		slog.ErrorContext(ctx, "Invalid browser version request configuration", "URL", url)
+		return nil, errBrowserVersionsRequest
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to create browser version request", "URL", url, common.ErrAttr(err))
+		return nil, errBrowserVersionsRequest
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to fetch browser version", "URL", url, common.ErrAttr(err))
+		return nil, common.NewRetriableError(errBrowserVersionsRequest)
+	}
+	defer resp.Body.Close()
+
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, browserVersionsMaxBytes+1))
+	attrs := []any{"URL", url, "code", resp.StatusCode, "response", browserVersionResponsePrefix(data)}
+	if readErr != nil {
+		attrs = append(attrs, common.ErrAttr(readErr))
+	}
+	if isRetriableBrowserVersionStatus(resp.StatusCode) {
+		slog.ErrorContext(ctx, "Browser version server request failed", attrs...)
+		return data, common.NewRetriableError(errBrowserVersionsResponse)
+	}
+	if resp.StatusCode != http.StatusOK {
+		slog.ErrorContext(ctx, "Browser version request failed", attrs...)
+		return data, errBrowserVersionsResponse
+	}
+	if readErr != nil {
+		slog.ErrorContext(ctx, "Failed to read browser version response", "URL", url, "code", resp.StatusCode, common.ErrAttr(readErr))
+		return nil, errBrowserVersionsResponse
+	}
+
+	return data, nil
+}
+
+func fetchBrowserVersionData(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	b := &backoff.Backoff{
+		Min:    time.Second,
+		Max:    10 * time.Second,
+		Factor: 2,
+		Jitter: true,
+	}
+
+	var data []byte
+	var err error
+	for attempt := 0; attempt < browserVersionAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				slog.ErrorContext(ctx, "Browser version request backoff interrupted", "URL", url, common.ErrAttr(ctx.Err()))
+				return data, errBrowserVersionsRequest
+			case <-time.After(b.Duration()):
+			}
+		}
+
+		data, err = doFetchBrowserVersionData(ctx, client, url)
+		var retriable common.RetriableError
+		if !errors.As(err, &retriable) {
+			return data, err
+		}
+		err = retriable.Unwrap()
+		slog.WarnContext(ctx, "Failed to fetch browser version", "URL", url, "attempt", attempt+1, common.ErrAttr(err))
+	}
+
+	return data, err
+}
+
+func fetchBrowserVersionResponse(ctx context.Context, client *http.Client, url string, target any) error {
+	data, err := fetchBrowserVersionData(ctx, client, url)
+	if err != nil {
+		return err
+	}
+	if target == nil || len(data) == 0 || len(data) > browserVersionsMaxBytes {
+		slog.ErrorContext(ctx, "Invalid browser version response size", "URL", url, "size", len(data))
+		return errBrowserVersionsResponse
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		slog.ErrorContext(ctx, "Failed to parse browser version response", "URL", url, "size", len(data), "response", browserVersionResponsePrefix(data), common.ErrAttr(err))
+		return errBrowserVersionsResponse
+	}
+	return nil
+}
+
+func (j *FetchBrowserVersionsJob) fetchChromeVersion(ctx context.Context, platform string) (string, error) {
+	var response struct {
+		Versions []struct {
+			Version string `json:"version"`
+		} `json:"versions"`
+	}
+	url := strings.ReplaceAll(j.ChromeURLTemplate, "{platform}", platform)
+	slog.DebugContext(ctx, "Fetching browser version", "browser", rules.BrowserChrome, "platform", platform)
+	if err := fetchBrowserVersionResponse(ctx, j.Client, url, &response); err != nil {
+		return "", err
+	}
+	if len(response.Versions) != 1 || response.Versions[0].Version == "" {
+		slog.ErrorContext(ctx, "Invalid Chrome version response", "platform", platform, "versions", len(response.Versions))
+		return "", errBrowserVersionsResponse
+	}
+	version := response.Versions[0].Version
+	slog.DebugContext(ctx, "Fetched browser version", "browser", rules.BrowserChrome, "platform", platform, "version", version)
+	return version, nil
+}
+
+func (j *FetchBrowserVersionsJob) fetchFirefoxVersion(ctx context.Context) (string, error) {
+	var response struct {
+		Latest string `json:"LATEST_FIREFOX_VERSION"`
+	}
+	slog.DebugContext(ctx, "Fetching browser version", "browser", rules.BrowserFirefox)
+	if err := fetchBrowserVersionResponse(ctx, j.Client, j.FirefoxURL, &response); err != nil {
+		return "", err
+	}
+	if response.Latest == "" {
+		slog.ErrorContext(ctx, "Invalid Firefox version response")
+		return "", errBrowserVersionsResponse
+	}
+	slog.DebugContext(ctx, "Fetched browser version", "browser", rules.BrowserFirefox, "version", response.Latest)
+	return response.Latest, nil
+}
+
+func (j *FetchBrowserVersionsJob) fetchFirefoxMobileVersion(ctx context.Context) (string, error) {
+	var response struct {
+		Version string `json:"version"`
+	}
+	slog.DebugContext(ctx, "Fetching browser version", "browser", rules.BrowserFirefox, "platform", rules.PlatformAndroid)
+	if err := fetchBrowserVersionResponse(ctx, j.Client, j.FirefoxMobileURL, &response); err != nil {
+		return "", err
+	}
+	if response.Version == "" {
+		slog.ErrorContext(ctx, "Invalid Firefox mobile version response")
+		return "", errBrowserVersionsResponse
+	}
+	slog.DebugContext(ctx, "Fetched browser version", "browser", rules.BrowserFirefox, "platform", rules.PlatformAndroid, "version", response.Version)
+	return response.Version, nil
+}
+
+func fetchBrowserVersionSources(ctx context.Context, sources []browserVersionSource) (*BrowserVersionsSnapshot, error) {
+	results := make([]browserVersionResult, len(sources))
+	sem := make(chan struct{}, browserVersionMaxConcurrency)
+	var wg sync.WaitGroup
+
+	for i, source := range sources {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			logger := slog.With("browser", source.browser)
+			if len(source.platforms) == 1 {
+				logger = logger.With("platform", source.platforms[0])
+			}
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				logger.ErrorContext(ctx, "Failed to acquire browser version fetch slot", common.ErrAttr(ctx.Err()))
+				results[i].err = errBrowserVersionsRequest
+				return
+			}
+
+			results[i].version, results[i].err = source.fetch(ctx)
+			if results[i].err != nil {
+				logger.ErrorContext(ctx, "Failed to fetch browser version", common.ErrAttr(results[i].err))
+			}
+		}()
+	}
+
+	wg.Wait()
+	snapshot := &BrowserVersionsSnapshot{Versions: make([]BrowserVersionRecord, 0, len(supportedBrowserVersionKeys))}
+	for i, result := range results {
+		if result.err != nil {
+			return nil, result.err
+		}
+		for _, platform := range sources[i].platforms {
+			snapshot.Versions = append(snapshot.Versions, BrowserVersionRecord{
+				Browser:  sources[i].browser,
+				Platform: platform,
+				Version:  result.version,
+			})
+		}
+	}
+	return snapshot, nil
+}
+
+func (j *FetchBrowserVersionsJob) fetchSnapshot(ctx context.Context) (*BrowserVersionsSnapshot, error) {
+	platforms := []struct {
+		api  string
+		name string
+	}{
+		{api: chromePlatformWindows, name: rules.PlatformWindows},
+		{api: chromePlatformMacOS, name: rules.PlatformMacOS},
+		{api: chromePlatformLinux, name: rules.PlatformLinux},
+		{api: chromePlatformAndroid, name: rules.PlatformAndroid},
+		{api: chromePlatformIOS, name: rules.PlatformIOS},
+	}
+
+	sources := make([]browserVersionSource, 0, len(platforms)+2)
+	for _, platform := range platforms {
+		sources = append(sources, browserVersionSource{
+			browser:   rules.BrowserChrome,
+			platforms: []string{platform.name},
+			fetch: func(ctx context.Context) (string, error) {
+				return j.fetchChromeVersion(ctx, platform.api)
+			},
+		})
+	}
+	sources = append(sources,
+		browserVersionSource{
+			browser:   rules.BrowserFirefox,
+			platforms: []string{rules.PlatformWindows, rules.PlatformMacOS, rules.PlatformLinux},
+			fetch:     j.fetchFirefoxVersion,
+		},
+		browserVersionSource{
+			browser:   rules.BrowserFirefox,
+			platforms: []string{rules.PlatformAndroid},
+			fetch:     j.fetchFirefoxMobileVersion,
+		},
+	)
+	return fetchBrowserVersionSources(ctx, sources)
+}
+
+func (j *FetchBrowserVersionsJob) runOnce(ctx context.Context) error {
+	if j.Store == nil {
+		slog.ErrorContext(ctx, "Browser version store is not configured")
+		return errBrowserVersionsStorage
+	}
+	snapshot, err := j.fetchSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	majors, err := browserVersionMajors(ctx, snapshot)
+	if err != nil {
+		return err
+	}
+	if err := j.validateUpdate(ctx, majors); err != nil {
+		return err
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to encode browser versions", common.ErrAttr(err))
+		return errBrowserVersionsResponse
+	}
+	if err := j.Store.Impl().StoreInCache(ctx, BrowserVersionsCacheKey, data, browserVersionsCacheTTL); err != nil {
+		slog.ErrorContext(ctx, "Failed to store browser versions", common.ErrAttr(err))
+		return errBrowserVersionsStorage
+	}
+
+	select {
+	case j.RefreshTrigger <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (j *FetchBrowserVersionsJob) validateUpdate(ctx context.Context, next map[rules.BrowserVersionKey]int) error {
+	data, err := j.Store.Impl().RetrieveFromCache(ctx, BrowserVersionsCacheKey)
+	if errors.Is(err, db.ErrCacheMiss) {
+		return nil
+	}
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to retrieve current browser versions", common.ErrAttr(err))
+		return errBrowserVersionsStorage
+	}
+	if len(data) == 0 {
+		slog.ErrorContext(ctx, "Current browser version snapshot is empty")
+		return errBrowserVersionsResponse
+	}
+
+	var snapshot BrowserVersionsSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		slog.ErrorContext(ctx, "Failed to decode current browser versions", "size", len(data), "response", browserVersionResponsePrefix(data), common.ErrAttr(err))
+		return errBrowserVersionsResponse
+	}
+	current, err := currentBrowserVersionMajors(ctx, &snapshot)
+	if err != nil {
+		return err
+	}
+	for key, currentMajor := range current {
+		nextMajor := next[key]
+		if nextMajor < currentMajor || nextMajor-currentMajor > browserVersionMaxJump {
+			slog.ErrorContext(ctx, "Unsafe browser version change", "browser", key.Browser, "platform", key.Platform, "current", currentMajor, "next", nextMajor)
+			return errBrowserVersionsResponse
+		}
+	}
+	return nil
+}
+
+func (j *FetchBrowserVersionsJob) RunOnce(ctx context.Context, _ any) error {
+	err := j.runOnce(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to fetch browser versions", common.ErrAttr(err))
+	}
+	return err
+}
+
+func parseBrowserVersionMajor(ctx context.Context, version string) (int, error) {
+	if len(version) == 0 || len(version) > browserVersionMaxLength {
+		slog.ErrorContext(ctx, "Browser version length is invalid", "length", len(version))
+		return 0, errBrowserVersionsResponse
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 || len(parts) > browserVersionMaxParts {
+		slog.ErrorContext(ctx, "Browser version component count is invalid", "version", browserVersionResponsePrefix([]byte(version)), "components", len(parts))
+		return 0, errBrowserVersionsResponse
+	}
+
+	major := 0
+	for i, part := range parts {
+		if part == "" {
+			slog.ErrorContext(ctx, "Browser version has an empty component", "version", browserVersionResponsePrefix([]byte(version)), "component", i)
+			return 0, errBrowserVersionsResponse
+		}
+		for _, digit := range part {
+			if digit < '0' || digit > '9' {
+				slog.ErrorContext(ctx, "Browser version has a non-numeric component", "version", browserVersionResponsePrefix([]byte(version)), "component", i)
+				return 0, errBrowserVersionsResponse
+			}
+		}
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			slog.ErrorContext(ctx, "Browser version component overflow", "version", browserVersionResponsePrefix([]byte(version)), "component", i, common.ErrAttr(err))
+			return 0, errBrowserVersionsResponse
+		}
+		if i == 0 {
+			major = value
+		}
+	}
+	if major <= 0 || major > browserVersionMaxMajor {
+		slog.ErrorContext(ctx, "Browser version major is implausible", "version", browserVersionResponsePrefix([]byte(version)), "major", major)
+		return 0, errBrowserVersionsResponse
+	}
+	return major, nil
+}
+
+func browserVersionMajorsForKeys(ctx context.Context, snapshot *BrowserVersionsSnapshot, supportedKeys map[rules.BrowserVersionKey]struct{}) (map[rules.BrowserVersionKey]int, error) {
+	if snapshot == nil || len(snapshot.Versions) != len(supportedKeys) {
+		records := 0
+		if snapshot != nil {
+			records = len(snapshot.Versions)
+		}
+		slog.ErrorContext(ctx, "Browser version snapshot is incomplete", "records", records, "expected", len(supportedKeys))
+		return nil, errBrowserVersionsResponse
+	}
+
+	versions := make(map[rules.BrowserVersionKey]int, len(snapshot.Versions))
+	for _, record := range snapshot.Versions {
+		key := rules.BrowserVersionKey{Browser: record.Browser, Platform: record.Platform}
+		if _, ok := supportedKeys[key]; !ok {
+			slog.ErrorContext(ctx, "Browser version is unsupported", "browser", record.Browser, "platform", record.Platform)
+			return nil, errBrowserVersionsResponse
+		}
+		if _, ok := versions[key]; ok {
+			slog.ErrorContext(ctx, "Browser version is duplicated", "browser", record.Browser, "platform", record.Platform)
+			return nil, errBrowserVersionsResponse
+		}
+		major, err := parseBrowserVersionMajor(ctx, record.Version)
+		if err != nil {
+			return nil, err
+		}
+		versions[key] = major
+	}
+	return versions, nil
+}
+
+func browserVersionMajors(ctx context.Context, snapshot *BrowserVersionsSnapshot) (map[rules.BrowserVersionKey]int, error) {
+	return browserVersionMajorsForKeys(ctx, snapshot, supportedBrowserVersionKeys)
+}
+
+func currentBrowserVersionMajors(ctx context.Context, snapshot *BrowserVersionsSnapshot) (map[rules.BrowserVersionKey]int, error) {
+	if snapshot != nil && len(snapshot.Versions) == len(legacyBrowserVersionKeys) {
+		return browserVersionMajorsForKeys(ctx, snapshot, legacyBrowserVersionKeys)
+	}
+	return browserVersionMajors(ctx, snapshot)
+}
+
+func (j *RefreshBrowserVersionsJob) runOnce(ctx context.Context) error {
+	if j.Store == nil || j.BrowserVersions == nil {
+		slog.ErrorContext(ctx, "Browser version refresh is not configured", "hasStore", j.Store != nil, "hasBrowserVersions", j.BrowserVersions != nil)
+		return errBrowserVersionsStorage
+	}
+
+	data, err := j.Store.Impl().RetrieveFromCache(ctx, BrowserVersionsCacheKey)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to retrieve cached browser versions", common.ErrAttr(err))
+		return errBrowserVersionsStorage
+	}
+	var snapshot BrowserVersionsSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		slog.ErrorContext(ctx, "Failed to decode cached browser versions", "size", len(data), "response", browserVersionResponsePrefix(data), common.ErrAttr(err))
+		return errBrowserVersionsResponse
+	}
+	versions, err := browserVersionMajors(ctx, &snapshot)
+	if err != nil {
+		return err
+	}
+
+	j.BrowserVersions.Replace(versions)
+	return nil
+}
+
+func (j *RefreshBrowserVersionsJob) RunOnce(ctx context.Context, _ any) error {
+	err := j.runOnce(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to refresh browser versions", common.ErrAttr(err))
+	}
+	return err
+}

--- a/pkg/maintenance/browser_versions_test.go
+++ b/pkg/maintenance/browser_versions_test.go
@@ -1,0 +1,571 @@
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/common"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/db"
+	dbgen "github.com/PrivateCaptcha/PrivateCaptcha/pkg/db/generated"
+	"github.com/PrivateCaptcha/PrivateCaptcha/pkg/rules"
+	"github.com/jackc/pgx/v5"
+)
+
+type browserVersionCacheQuerier struct {
+	*db.QuerierStub
+	arg      *dbgen.CreateCacheParams
+	readKey  string
+	readData []byte
+	readErr  error
+}
+
+type browserVersionRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f browserVersionRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+type browserVersionErrorReader struct{}
+
+func (browserVersionErrorReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (q *browserVersionCacheQuerier) CreateCache(_ context.Context, arg *dbgen.CreateCacheParams) (int64, error) {
+	if q.Error != nil {
+		return 0, q.Error
+	}
+	q.arg = arg
+	return 1, nil
+}
+
+func (q *browserVersionCacheQuerier) GetCachedByKey(_ context.Context, key string) ([]byte, error) {
+	q.readKey = key
+	if q.readData == nil && q.readErr == nil {
+		return nil, pgx.ErrNoRows
+	}
+	return q.readData, q.readErr
+}
+
+func newBrowserVersionTestStore(q *browserVersionCacheQuerier) *db.BusinessStore {
+	return db.NewBusinessWithQuerier(nil, q, db.NewStaticCache[db.CacheKey, any](10, &db.CacheMissingValue{}))
+}
+
+func newBrowserVersionTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	versions := map[string]string{
+		"win":            "152.0.7977.42",
+		"mac":            "151.0.7922.139",
+		"linux":          "150.0.7871.186",
+		"android":        "154.0.8000.10",
+		"ios":            "155.0.8100.20",
+		"firefox":        "153.0.4",
+		"firefox-mobile": "154.0.1",
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/firefox" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"LATEST_FIREFOX_VERSION": versions["firefox"]})
+			return
+		}
+		if r.URL.Path == "/firefox-mobile" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"version": versions["firefox-mobile"]})
+			return
+		}
+
+		platform := strings.TrimPrefix(r.URL.Path, "/chrome/")
+		version, ok := versions[platform]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"versions": []map[string]string{{"version": version}},
+		})
+	}))
+}
+
+func newFetchBrowserVersionsTestJob(querier *browserVersionCacheQuerier, server *httptest.Server) *FetchBrowserVersionsJob {
+	job := NewFetchBrowserVersionsJob(newBrowserVersionTestStore(querier))
+	job.Client = server.Client()
+	job.ChromeURLTemplate = server.URL + "/chrome/{platform}"
+	job.FirefoxURL = server.URL + "/firefox"
+	job.FirefoxMobileURL = server.URL + "/firefox-mobile"
+	return job
+}
+
+func TestFetchBrowserVersionsJobStoresFullSnapshotAndTriggers(t *testing.T) {
+	ts := newBrowserVersionTestServer(t)
+	defer ts.Close()
+
+	querier := &browserVersionCacheQuerier{
+		QuerierStub: &db.QuerierStub{},
+		readData:    browserVersionSnapshotData(t, validBrowserVersionRecords()),
+	}
+	trigger := make(chan struct{}, 1)
+	job := newFetchBrowserVersionsTestJob(querier, ts)
+	job.RefreshTrigger = trigger
+
+	if err := job.RunOnce(t.Context(), job.NewParams()); err != nil {
+		t.Fatal(err)
+	}
+	if querier.arg == nil {
+		t.Fatal("browser versions were not stored")
+	}
+	if querier.arg.Key != BrowserVersionsCacheKey {
+		t.Fatalf("cache key = %q, want %q", querier.arg.Key, BrowserVersionsCacheKey)
+	}
+	if querier.arg.Column3 != 7*24*time.Hour {
+		t.Fatalf("cache TTL = %v, want 7 days", querier.arg.Column3)
+	}
+
+	var snapshot BrowserVersionsSnapshot
+	if err := json.Unmarshal(querier.arg.Value, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	want := validBrowserVersionRecords()
+	if fmt.Sprint(snapshot.Versions) != fmt.Sprint(want) {
+		t.Fatalf("stored versions = %+v, want %+v", snapshot.Versions, want)
+	}
+	select {
+	case <-trigger:
+	default:
+		t.Fatal("refresh was not triggered after storing versions")
+	}
+}
+
+func TestFetchBrowserVersionsJobRejectsUnsafeOrInvalidCurrentSnapshot(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		data    []byte
+		readErr error
+		wantErr error
+	}{
+		{name: "Rollback", version: "160.0.0.0", wantErr: errBrowserVersionsResponse},
+		{name: "LargeJump", version: "100.0.0.0", wantErr: errBrowserVersionsResponse},
+		{name: "IncompleteSnapshot", data: browserVersionSnapshotData(t, validBrowserVersionRecords()[:8]), wantErr: errBrowserVersionsResponse},
+		{name: "CacheReadFailure", readErr: errors.New("read failed"), wantErr: errBrowserVersionsStorage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newBrowserVersionTestServer(t)
+			defer ts.Close()
+
+			data := tt.data
+			if data == nil {
+				records := validBrowserVersionRecords()
+				if tt.version != "" {
+					records[0].Version = tt.version
+				}
+				data = browserVersionSnapshotData(t, records)
+			}
+			querier := &browserVersionCacheQuerier{
+				QuerierStub: &db.QuerierStub{},
+				readData:    data,
+				readErr:     tt.readErr,
+			}
+			job := newFetchBrowserVersionsTestJob(querier, ts)
+
+			if err := job.RunOnce(t.Context(), job.NewParams()); err != tt.wantErr {
+				t.Fatalf("RunOnce error = %v, want %v", err, tt.wantErr)
+			}
+			if querier.arg != nil {
+				t.Fatal("unsafe browser versions were stored")
+			}
+		})
+	}
+}
+
+func TestFetchBrowserVersionsJobReplacesLegacyDesktopSnapshot(t *testing.T) {
+	ts := newBrowserVersionTestServer(t)
+	defer ts.Close()
+
+	querier := &browserVersionCacheQuerier{
+		QuerierStub: &db.QuerierStub{},
+		readData:    browserVersionSnapshotData(t, legacyBrowserVersionRecords()),
+	}
+	job := newFetchBrowserVersionsTestJob(querier, ts)
+
+	if err := job.RunOnce(t.Context(), job.NewParams()); err != nil {
+		t.Fatal(err)
+	}
+	if querier.arg == nil {
+		t.Fatal("legacy browser versions were not replaced")
+	}
+}
+
+func TestFetchBrowserVersionsJobDoesNotStorePartialSnapshot(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/firefox" {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte(`{"versions":[{"version":"152.0.1.2"}]}`))
+	}))
+	defer ts.Close()
+
+	querier := &browserVersionCacheQuerier{QuerierStub: &db.QuerierStub{}}
+	trigger := make(chan struct{}, 1)
+	job := newFetchBrowserVersionsTestJob(querier, ts)
+	job.RefreshTrigger = trigger
+
+	if err := job.RunOnce(t.Context(), job.NewParams()); err == nil {
+		t.Fatal("expected Firefox fetch failure")
+	}
+	if querier.arg != nil {
+		t.Fatal("partial browser versions were stored")
+	}
+	select {
+	case <-trigger:
+		t.Fatal("refresh was triggered after fetch failure")
+	default:
+	}
+}
+
+func TestFetchBrowserVersionsJobDoesNotTriggerAfterStoreFailure(t *testing.T) {
+	ts := newBrowserVersionTestServer(t)
+	defer ts.Close()
+
+	storeErr := errors.New("store failed")
+	querier := &browserVersionCacheQuerier{QuerierStub: &db.QuerierStub{Error: storeErr}}
+	trigger := make(chan struct{}, 1)
+	job := newFetchBrowserVersionsTestJob(querier, ts)
+	job.RefreshTrigger = trigger
+
+	if err := job.RunOnce(t.Context(), job.NewParams()); err != errBrowserVersionsStorage {
+		t.Fatalf("RunOnce error = %v, want %v", err, errBrowserVersionsStorage)
+	}
+	select {
+	case <-trigger:
+		t.Fatal("refresh was triggered after store failure")
+	default:
+	}
+}
+
+func TestFetchBrowserVersionsJobRejectsInvalidSourceData(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "MalformedJSON",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"versions":`))
+			},
+		},
+		{
+			name: "OversizedResponse",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"versions":[{"version":"` + strings.Repeat("1", browserVersionsMaxBytes) + `"}]}`))
+			},
+		},
+		{
+			name: "MissingVersion",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/firefox" {
+					_, _ = w.Write([]byte(`{"LATEST_FIREFOX_VERSION":""}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"versions":[{"version":"152.0.1.2"}]}`))
+			},
+		},
+		{
+			name: "MultipleChromeVersions",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"versions":[{"version":"152.0.1.2"},{"version":"152.0.1.2"}]}`))
+			},
+		},
+		{
+			name: "MalformedFirefoxMobileVersion",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/firefox":
+					_, _ = w.Write([]byte(`{"LATEST_FIREFOX_VERSION":"153.0.4"}`))
+				case "/firefox-mobile":
+					_, _ = w.Write([]byte(`{"version":"not-a-version"}`))
+				default:
+					_, _ = w.Write([]byte(`{"versions":[{"version":"152.0.1.2"}]}`))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(tt.handler)
+			defer ts.Close()
+
+			querier := &browserVersionCacheQuerier{QuerierStub: &db.QuerierStub{}}
+			job := newFetchBrowserVersionsTestJob(querier, ts)
+
+			if err := job.RunOnce(t.Context(), job.NewParams()); err == nil {
+				t.Fatal("expected invalid response error")
+			}
+			if querier.arg != nil {
+				t.Fatal("invalid browser versions were stored")
+			}
+		})
+	}
+	t.Run("Redirect", func(t *testing.T) {
+		job := NewFetchBrowserVersionsJob(nil)
+		if err := job.Client.CheckRedirect(&http.Request{}, nil); !errors.Is(err, http.ErrUseLastResponse) {
+			t.Fatalf("redirect error = %v, want %v", err, http.ErrUseLastResponse)
+		}
+	})
+}
+
+func TestFetchBrowserVersionsJobCoalescesRefreshTriggers(t *testing.T) {
+	ts := newBrowserVersionTestServer(t)
+	defer ts.Close()
+
+	querier := &browserVersionCacheQuerier{QuerierStub: &db.QuerierStub{}}
+	trigger := make(chan struct{}, 1)
+	trigger <- struct{}{}
+	job := newFetchBrowserVersionsTestJob(querier, ts)
+	job.RefreshTrigger = trigger
+
+	done := make(chan error, 1)
+	go func() { done <- job.RunOnce(t.Context(), job.NewParams()) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunOnce blocked on a full refresh trigger")
+	}
+}
+
+func TestFetchBrowserVersionsJobRetryPolicy(t *testing.T) {
+	t.Run("TransientStatus", func(t *testing.T) {
+		var attempts atomic.Int32
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if attempts.Add(1) == 1 {
+				http.Error(w, "server error", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`{"versions":[{"version":"152.0.1.2"}]}`))
+		}))
+		defer ts.Close()
+
+		job := NewFetchBrowserVersionsJob(nil)
+		job.Client = ts.Client()
+		job.ChromeURLTemplate = ts.URL + "/{platform}"
+		version, err := job.fetchChromeVersion(t.Context(), chromePlatformWindows)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if version != "152.0.1.2" || attempts.Load() != 2 {
+			t.Fatalf("version = %q after %d attempts", version, attempts.Load())
+		}
+	})
+
+	t.Run("TransportFailure", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"versions":[{"version":"152.0.1.2"}]}`))
+		}))
+		defer ts.Close()
+
+		var attempts atomic.Int32
+		transport := ts.Client().Transport
+		job := NewFetchBrowserVersionsJob(nil)
+		job.Client = &http.Client{Transport: browserVersionRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if attempts.Add(1) == 1 {
+				return nil, errors.New("transport failed")
+			}
+			return transport.RoundTrip(r)
+		})}
+		job.ChromeURLTemplate = ts.URL + "/{platform}"
+		version, err := job.fetchChromeVersion(t.Context(), chromePlatformWindows)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if version != "152.0.1.2" || attempts.Load() != 2 {
+			t.Fatalf("version = %q attempts = %d", version, attempts.Load())
+		}
+	})
+
+	t.Run("PermanentStatus", func(t *testing.T) {
+		var attempts atomic.Int32
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts.Add(1)
+			http.Error(w, "bad request", http.StatusBadRequest)
+		}))
+		defer ts.Close()
+
+		job := NewFetchBrowserVersionsJob(nil)
+		job.Client = ts.Client()
+		job.ChromeURLTemplate = ts.URL + "/{platform}"
+		if _, err := job.fetchChromeVersion(t.Context(), chromePlatformWindows); err != errBrowserVersionsResponse {
+			t.Fatalf("fetch error = %v, want %v", err, errBrowserVersionsResponse)
+		}
+		if attempts.Load() != 1 {
+			t.Fatalf("attempts = %d, want 1", attempts.Load())
+		}
+	})
+}
+
+func TestBrowserVersionRetriableStatus(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusRequestTimeout, http.StatusTooEarly} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			if !isRetriableBrowserVersionStatus(status) {
+				t.Fatalf("isRetriableBrowserVersionStatus(%d) = false, want true", status)
+			}
+		})
+	}
+}
+
+func TestBrowserVersionRetryableStatusWinsOverBodyReadFailure(t *testing.T) {
+	client := &http.Client{Transport: browserVersionRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(browserVersionErrorReader{}),
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})}
+
+	_, err := doFetchBrowserVersionData(t.Context(), client, "http://example.com")
+	var retriable common.RetriableError
+	if !errors.As(err, &retriable) {
+		t.Fatalf("fetch error = %v, want retriable error", err)
+	}
+	if retriable.Unwrap() != errBrowserVersionsResponse {
+		t.Fatalf("retriable error = %v, want %v", retriable.Unwrap(), errBrowserVersionsResponse)
+	}
+}
+
+func validBrowserVersionRecords() []BrowserVersionRecord {
+	return []BrowserVersionRecord{
+		{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows, Version: "152.0.7977.42"},
+		{Browser: rules.BrowserChrome, Platform: rules.PlatformMacOS, Version: "151.0.7922.139"},
+		{Browser: rules.BrowserChrome, Platform: rules.PlatformLinux, Version: "150.0.7871.186"},
+		{Browser: rules.BrowserChrome, Platform: rules.PlatformAndroid, Version: "154.0.8000.10"},
+		{Browser: rules.BrowserChrome, Platform: rules.PlatformIOS, Version: "155.0.8100.20"},
+		{Browser: rules.BrowserFirefox, Platform: rules.PlatformWindows, Version: "153.0.4"},
+		{Browser: rules.BrowserFirefox, Platform: rules.PlatformMacOS, Version: "153.0.4"},
+		{Browser: rules.BrowserFirefox, Platform: rules.PlatformLinux, Version: "153.0.4"},
+		{Browser: rules.BrowserFirefox, Platform: rules.PlatformAndroid, Version: "154.0.1"},
+	}
+}
+
+func legacyBrowserVersionRecords() []BrowserVersionRecord {
+	records := validBrowserVersionRecords()
+	return append(append([]BrowserVersionRecord{}, records[:3]...), records[5:8]...)
+}
+
+func browserVersionSnapshotData(t *testing.T, records []BrowserVersionRecord) []byte {
+	t.Helper()
+	data, err := json.Marshal(BrowserVersionsSnapshot{Versions: records})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestRefreshBrowserVersionsJobParsesAndReplacesSnapshot(t *testing.T) {
+	querier := &browserVersionCacheQuerier{
+		QuerierStub: &db.QuerierStub{},
+		readData:    browserVersionSnapshotData(t, validBrowserVersionRecords()),
+	}
+	provider := rules.NewBrowserVersions()
+	job := NewRefreshBrowserVersionsJob(newBrowserVersionTestStore(querier), provider)
+
+	if err := job.RunOnce(t.Context(), job.NewParams()); err != nil {
+		t.Fatal(err)
+	}
+	if querier.readKey != BrowserVersionsCacheKey {
+		t.Fatalf("cache key = %q, want %q", querier.readKey, BrowserVersionsCacheKey)
+	}
+
+	want := map[rules.BrowserVersionKey]int{
+		{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows}:  152,
+		{Browser: rules.BrowserChrome, Platform: rules.PlatformIOS}:      155,
+		{Browser: rules.BrowserFirefox, Platform: rules.PlatformAndroid}: 154,
+	}
+	for key, wantMajor := range want {
+		major, ok := provider.Major(key)
+		if !ok || major != wantMajor {
+			t.Fatalf("Major(%+v) = %d, %v, want %d, true", key, major, ok, wantMajor)
+		}
+	}
+}
+
+func TestRefreshBrowserVersionsJobPreservesProviderOnFailure(t *testing.T) {
+	t.Run("InitialCacheMiss", func(t *testing.T) {
+		querier := &browserVersionCacheQuerier{QuerierStub: &db.QuerierStub{}, readErr: pgx.ErrNoRows}
+		provider := rules.NewBrowserVersions()
+		job := NewRefreshBrowserVersionsJob(newBrowserVersionTestStore(querier), provider)
+		if err := job.RunOnce(t.Context(), job.NewParams()); err != errBrowserVersionsStorage {
+			t.Fatalf("RunOnce error = %v, want %v", err, errBrowserVersionsStorage)
+		}
+		key := rules.BrowserVersionKey{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows}
+		if _, ok := provider.Major(key); ok {
+			t.Fatalf("initial failure populated provider key %+v", key)
+		}
+	})
+
+	dbErr := errors.New("read failed")
+	validRecords := validBrowserVersionRecords()
+	tests := []struct {
+		name string
+		data []byte
+		err  error
+	}{
+		{name: "DatabaseError", err: dbErr},
+		{name: "MalformedJSON", data: []byte(`{"versions":`)},
+		{name: "EmptyVersion", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows}}, validRecords[1:]...))},
+		{name: "MajorOnlyVersion", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows, Version: "152"}}, validRecords[1:]...))},
+		{name: "ZeroMajorVersion", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows, Version: "0.1"}}, validRecords[1:]...))},
+		{name: "MalformedVersion", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows, Version: "152.x.1"}}, validRecords[1:]...))},
+		{name: "VersionOverflow", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows, Version: "999999999999999999999.0"}}, validRecords[1:]...))},
+		{name: "TooManyVersionComponents", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows, Version: "152.0.1.2.3"}}, validRecords[1:]...))},
+		{name: "ImplausibleMajorVersion", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: rules.BrowserChrome, Platform: rules.PlatformWindows, Version: "1001.0"}}, validRecords[1:]...))},
+		{name: "DuplicateRecord", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{validRecords[0]}, validRecords[:8]...))},
+		{name: "IncompleteSnapshot", data: browserVersionSnapshotData(t, validRecords[:8])},
+		{name: "UnknownRecord", data: browserVersionSnapshotData(t, append([]BrowserVersionRecord{{Browser: "safari", Platform: rules.PlatformMacOS, Version: "18.0"}}, validRecords[1:]...))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := rules.NewBrowserVersions()
+			lastKnownGood := make(map[rules.BrowserVersionKey]int, len(validRecords))
+			for _, record := range validRecords {
+				lastKnownGood[rules.BrowserVersionKey{Browser: record.Browser, Platform: record.Platform}] = 149
+			}
+			provider.Replace(lastKnownGood)
+
+			querier := &browserVersionCacheQuerier{
+				QuerierStub: &db.QuerierStub{},
+				readData:    tt.data,
+				readErr:     tt.err,
+			}
+			job := NewRefreshBrowserVersionsJob(newBrowserVersionTestStore(querier), provider)
+			if err := job.RunOnce(t.Context(), job.NewParams()); err == nil {
+				t.Fatal("expected refresh failure")
+			}
+
+			for key, wantMajor := range lastKnownGood {
+				major, ok := provider.Major(key)
+				if !ok || major != wantMajor {
+					t.Fatalf("Major(%+v) after failure = %d, %v, want %d, true", key, major, ok, wantMajor)
+				}
+			}
+			if _, ok := provider.Major(rules.BrowserVersionKey{Browser: "safari", Platform: rules.PlatformMacOS}); ok {
+				t.Fatal("failure introduced an unsupported browser version")
+			}
+		})
+	}
+}

--- a/pkg/portal/render.go
+++ b/pkg/portal/render.go
@@ -90,12 +90,14 @@ type RenderConstants struct {
 	ConditionPropertyDomain         string
 	ConditionPropertyHTTPHeaderName string
 	ConditionPropertyAlways         string
+	ConditionPropertyBrowserVersion string
 	OperatorEquals                  string
 	OperatorContains                string
 	OperatorEmpty                   string
 	OperatorMatches                 string
 	OperatorIn                      string
 	OperatorBot                     string
+	OperatorMore                    string
 	StringOperators                 []string
 	IPOperators                     []string
 	GrowthTypeConstant              string
@@ -199,6 +201,7 @@ func NewRenderConstants() *RenderConstants {
 		OperatorMatches:                 string(dbgen.RuleConditionOperatorMatches),
 		OperatorIn:                      string(dbgen.RuleConditionOperatorIn),
 		OperatorBot:                     string(dbgen.RuleConditionOperatorBot),
+		OperatorMore:                    string(dbgen.RuleConditionOperatorMore),
 		StringOperators:                 []string{string(dbgen.RuleConditionOperatorEquals), string(dbgen.RuleConditionOperatorContains), string(dbgen.RuleConditionOperatorEmpty)},
 		IPOperators:                     []string{string(dbgen.RuleConditionOperatorMatches), string(dbgen.RuleConditionOperatorEmpty)},
 		ConditionProperty:               common.ParamConditionProperty,
@@ -208,6 +211,7 @@ func NewRenderConstants() *RenderConstants {
 		ConditionPropertyDomain:         string(dbgen.RuleConditionPropertyDomain),
 		ConditionPropertyHTTPHeaderName: string(dbgen.RuleConditionPropertyHTTPHeaderName),
 		ConditionPropertyAlways:         string(dbgen.RuleConditionPropertyAlways),
+		ConditionPropertyBrowserVersion: string(dbgen.RuleConditionPropertyBrowserVersion),
 		GrowthTypeConstant:              string(dbgen.DifficultyGrowthConstant),
 		GrowthTypeSlow:                  string(dbgen.DifficultyGrowthSlow),
 		GrowthTypeMedium:                string(dbgen.DifficultyGrowthMedium),

--- a/pkg/portal/render_test.go
+++ b/pkg/portal/render_test.go
@@ -743,6 +743,33 @@ func TestRenderHTML(t *testing.T) {
 			matches:  []string{},
 		},
 		{
+			path:     []string{common.OrgEndpoint, "123", common.PropertyEndpoint, "456", common.RulesEndpoint, "browser-version", common.EditEndpoint},
+			template: ruleTemplate,
+			model: &RuleWizardRenderContext{
+				CsrfRenderContext: stubToken(),
+				RuleFormData: RuleFormData{
+					Name:              "Outdated browser",
+					ConditionProperty: string(dbgen.RuleConditionPropertyBrowserVersion),
+					ConditionOperator: string(dbgen.RuleConditionOperatorMore),
+					ConditionValue:    "7",
+					ActionProperty:    string(dbgen.RuleActionPropertyDifficultyLevelPercent),
+					ActionValue:       "50",
+					Enabled:           true,
+				},
+				CurrentOrg: stubOrg("123"),
+				Property:   stubProperty("my property", "123"),
+				IsEdit:     true,
+			},
+			selector: `option[value="browser_version"][selected], label[for="browserVersionInput"], input#browserVersionInput[type="number"][min="1"][step="1"][aria-describedby="browserVersionInput-description"], #browserVersionInput-description`,
+			matches: []string{
+				"Browser version",
+				"Major versions behind",
+				"",
+				"Matches Chrome or Firefox versions more than this many major versions behind the latest release.",
+			},
+			enterprise: enterpriseOnly,
+		},
+		{
 			path:     []string{common.OrgEndpoint, "123", common.RulesEndpoint},
 			template: orgRulesTemplate,
 			model: &OrgRulesRenderContext{

--- a/pkg/portal/rules.go
+++ b/pkg/portal/rules.go
@@ -133,10 +133,18 @@ type ConditionFormParser func(conditionOperator, conditionValue, domain string) 
 type ActionFormParser func(actionValue string) (int32, common.StatusCode)
 type ConditionValueFormatter func(rule *dbgen.DifficultyRule) string
 
+type conditionValueType uint8
+
+const (
+	conditionValueString conditionValueType = iota
+	conditionValueInteger
+)
+
 type ConditionRegistration struct {
 	Parser         ConditionFormParser
 	DisplayName    string
 	ValueFormatter ConditionValueFormatter
+	valueType      conditionValueType
 }
 
 type RuleRegistry struct {
@@ -153,7 +161,12 @@ func (r *RuleRegistry) RegisterCondition(key string, parser ConditionFormParser,
 		r.conditions = make(map[string]ConditionRegistration)
 	}
 
-	reg := ConditionRegistration{Parser: parser, DisplayName: displayName}
+	previous := r.conditions[key]
+	reg := ConditionRegistration{
+		Parser:      parser,
+		DisplayName: displayName,
+		valueType:   previous.valueType,
+	}
 	if valueFormatter != nil {
 		reg.ValueFormatter = valueFormatter
 	}
@@ -182,6 +195,11 @@ func (r *RuleRegistry) ConditionParser(key string) (ConditionFormParser, bool) {
 		return nil, false
 	}
 	return reg.Parser, true
+}
+
+func (r *RuleRegistry) conditionRegistration(key string) (ConditionRegistration, bool) {
+	reg, ok := r.conditions[key]
+	return reg, ok
 }
 
 func (r *RuleRegistry) ActionParser(key string) (ActionFormParser, bool) {

--- a/pkg/portal/rules_enterprise.go
+++ b/pkg/portal/rules_enterprise.go
@@ -4,6 +4,7 @@ package portal
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/netip"
@@ -216,6 +217,29 @@ func countryCodeConditionParser(conditionOperator, conditionValue, _ string) (st
 	return conditionValue, separator, common.StatusOK
 }
 
+func browserVersionConditionParser(conditionOperator, conditionValue, _ string) (string, string, common.StatusCode) {
+	if conditionOperator != string(dbgen.RuleConditionOperatorMore) {
+		return "", "", common.StatusRuleConditionOperatorInvalid
+	}
+	if conditionValue == "" {
+		return "", "", common.StatusRuleConditionValueRequired
+	}
+
+	value, err := strconv.ParseInt(conditionValue, 10, 32)
+	if err != nil || value <= 0 {
+		return "", "", common.StatusRuleConditionValueInvalid
+	}
+
+	return strconv.FormatInt(value, 10), "", common.StatusOK
+}
+
+func browserVersionConditionValueFormatter(rule *dbgen.DifficultyRule) string {
+	if !rule.ConditionValueInt.Valid {
+		return ""
+	}
+	return fmt.Sprintf("%d major versions behind", rule.ConditionValueInt.Int32)
+}
+
 func commaSeparatedConditionValueFormatter(rule *dbgen.DifficultyRule) string {
 	if !rule.ConditionValueStr.Valid {
 		return ""
@@ -349,7 +373,10 @@ func httpHeaderNameConditionParser(conditionOperator, conditionValue, _ string) 
 	return conditionValue, separator, common.StatusOK
 }
 
-func alwaysConditionParser(_, _, _ string) (string, string, common.StatusCode) {
+func alwaysConditionParser(conditionOperator, _, _ string) (string, string, common.StatusCode) {
+	if conditionOperator != string(dbgen.RuleConditionOperatorEquals) {
+		return "", "", common.StatusRuleConditionOperatorInvalid
+	}
 	return "", "", common.StatusOK
 }
 
@@ -366,6 +393,12 @@ func NewRuleRegistry() *RuleRegistry {
 			string(dbgen.RuleConditionPropertyDomain):         ConditionRegistration{Parser: domainConditionParser, DisplayName: "Domain"},
 			string(dbgen.RuleConditionPropertyHTTPHeaderName): ConditionRegistration{Parser: httpHeaderNameConditionParser, DisplayName: "HTTP Header Name"},
 			string(dbgen.RuleConditionPropertyAlways):         ConditionRegistration{Parser: alwaysConditionParser, DisplayName: "Always"},
+			string(dbgen.RuleConditionPropertyBrowserVersion): ConditionRegistration{
+				Parser:         browserVersionConditionParser,
+				DisplayName:    "Outdated browser version",
+				ValueFormatter: browserVersionConditionValueFormatter,
+				valueType:      conditionValueInteger,
+			},
 		},
 		actions: map[string]ActionFormParser{
 			string(dbgen.RuleActionPropertyDifficultyLevelPercent): difficultyActionParser,
@@ -648,7 +681,7 @@ func (s *Server) parseRuleForm(ctx context.Context, r *http.Request, renderCtx *
 		return nil, common.StatusRuleActionPropertyRequired
 	}
 
-	conditionParser, ok := s.Rules.ConditionParser(renderCtx.ConditionProperty)
+	condition, ok := s.Rules.conditionRegistration(renderCtx.ConditionProperty)
 	if !ok {
 		slog.WarnContext(ctx, "Invalid condition property", "condition", renderCtx.ConditionProperty)
 		return nil, common.StatusRuleConditionPropertyInvalid
@@ -673,7 +706,7 @@ func (s *Server) parseRuleForm(ctx context.Context, r *http.Request, renderCtx *
 		renderCtx.ConditionOperator = strings.TrimSuffix(renderCtx.ConditionOperator, "_negated")
 	}
 
-	normalizedValue, separatorStr, parseStatus := conditionParser(renderCtx.ConditionOperator, renderCtx.ConditionValue, domain)
+	normalizedValue, separatorStr, parseStatus := condition.Parser(renderCtx.ConditionOperator, renderCtx.ConditionValue, domain)
 	if !parseStatus.Success() {
 		slog.WarnContext(ctx, "Failed to parse rule condition", "condition", renderCtx.ConditionProperty, "operator", renderCtx.ConditionOperator,
 			"value", renderCtx.ConditionValue, "negated", renderCtx.ConditionNegated, "status", parseStatus.String())
@@ -681,9 +714,20 @@ func (s *Server) parseRuleForm(ctx context.Context, r *http.Request, renderCtx *
 	}
 	renderCtx.ConditionValue = normalizedValue
 
+	var conditionValueStr pgtype.Text
+	var conditionValueInt pgtype.Int4
 	var conditionValueSeparator pgtype.Text
-	if separatorStr != "" {
-		conditionValueSeparator = db.Text(separatorStr)
+	if condition.valueType == conditionValueInteger {
+		value, err := strconv.ParseInt(normalizedValue, 10, 32)
+		if err != nil {
+			return nil, common.StatusRuleConditionValueInvalid
+		}
+		conditionValueInt = db.Int(int32(value))
+	} else {
+		conditionValueStr = db.Text(normalizedValue)
+		if separatorStr != "" {
+			conditionValueSeparator = db.Text(separatorStr)
+		}
 	}
 
 	slog.DebugContext(ctx, "Parsed rule condition", "condition", renderCtx.ConditionProperty, "operator", renderCtx.ConditionOperator,
@@ -719,7 +763,8 @@ func (s *Server) parseRuleForm(ctx context.Context, r *http.Request, renderCtx *
 		ConditionProperty:        dbgen.RuleConditionProperty(renderCtx.ConditionProperty),
 		ConditionOperator:        dbgen.RuleConditionOperator(renderCtx.ConditionOperator),
 		ConditionOperatorNegated: renderCtx.ConditionNegated,
-		ConditionValueStr:        db.Text(renderCtx.ConditionValue),
+		ConditionValueStr:        conditionValueStr,
+		ConditionValueInt:        conditionValueInt,
 		ConditionValueSeparator:  conditionValueSeparator,
 		ActionProperty:           actionPropertyEnum,
 		ActionValue:              actionValue,
@@ -735,6 +780,8 @@ func ruleToFormData(rule *dbgen.DifficultyRule) RuleFormData {
 	conditionValue := ""
 	if rule.ConditionValueStr.Valid {
 		conditionValue = rule.ConditionValueStr.String
+	} else if rule.ConditionValueInt.Valid {
+		conditionValue = strconv.Itoa(int(rule.ConditionValueInt.Int32))
 	}
 
 	return RuleFormData{

--- a/pkg/portal/rules_test.go
+++ b/pkg/portal/rules_test.go
@@ -160,6 +160,28 @@ func postEditOrgRule(srv *http.ServeMux, cookie *http.Cookie, user *dbgen.User, 
 	return postRuleRequest(srv, cookie, "POST", endpoint, token, params)
 }
 
+func assertBrowserVersionRule(t *testing.T, rule *dbgen.DifficultyRule, threshold int32, negated bool) {
+	t.Helper()
+	if rule.ConditionProperty != dbgen.RuleConditionPropertyBrowserVersion {
+		t.Errorf("ConditionProperty = %q, want %q", rule.ConditionProperty, dbgen.RuleConditionPropertyBrowserVersion)
+	}
+	if rule.ConditionOperator != dbgen.RuleConditionOperatorMore {
+		t.Errorf("ConditionOperator = %q, want %q", rule.ConditionOperator, dbgen.RuleConditionOperatorMore)
+	}
+	if rule.ConditionOperatorNegated != negated {
+		t.Errorf("ConditionOperatorNegated = %v, want %v", rule.ConditionOperatorNegated, negated)
+	}
+	if !rule.ConditionValueInt.Valid || rule.ConditionValueInt.Int32 != threshold {
+		t.Errorf("ConditionValueInt = %+v, want valid %d", rule.ConditionValueInt, threshold)
+	}
+	if rule.ConditionValueStr.Valid {
+		t.Errorf("ConditionValueStr = %+v, want invalid", rule.ConditionValueStr)
+	}
+	if rule.ConditionValueSeparator.Valid {
+		t.Errorf("ConditionValueSeparator = %+v, want invalid", rule.ConditionValueSeparator)
+	}
+}
+
 func TestDifficultyRuleToDisplayConditionPropertyOverride(t *testing.T) {
 	hasher := common.NewIDHasher(config.NewStaticValue(common.IDHasherSaltKey, "salt"))
 
@@ -206,6 +228,50 @@ func TestDifficultyRuleToDisplayConditionPropertyOverride(t *testing.T) {
 	model = DifficultyRuleToDisplay(rule, true, hasher, registry)
 	if model.ConditionProperty != "My Custom Prop" {
 		t.Errorf("Expected 'My Custom Prop', got '%s'", model.ConditionProperty)
+	}
+}
+
+func TestBrowserVersionRuleToDisplay(t *testing.T) {
+	hasher := common.NewIDHasher(config.NewStaticValue(common.IDHasherSaltKey, "salt"))
+	rule := &dbgen.DifficultyRule{
+		ConditionProperty: dbgen.RuleConditionPropertyBrowserVersion,
+		ConditionOperator: dbgen.RuleConditionOperatorMore,
+		ConditionValueInt: db.Int(3),
+		ActionProperty:    dbgen.RuleActionPropertyDifficultyLevelPercent,
+		ActionValue:       20,
+	}
+
+	model := DifficultyRuleToDisplay(rule, true, hasher, NewRuleRegistry())
+	if model.ConditionProperty != "Outdated browser version" {
+		t.Errorf("ConditionProperty = %q, want %q", model.ConditionProperty, "Outdated browser version")
+	}
+	if model.ConditionOperator != "more" {
+		t.Errorf("ConditionOperator = %q, want %q", model.ConditionOperator, "more")
+	}
+	if model.ConditionValue != "3 major versions behind" {
+		t.Errorf("ConditionValue = %q, want %q", model.ConditionValue, "3 major versions behind")
+	}
+
+	rule.ConditionOperatorNegated = true
+	model = DifficultyRuleToDisplay(rule, true, hasher, NewRuleRegistry())
+	if model.ConditionOperator != "not more" {
+		t.Errorf("ConditionOperator = %q, want %q", model.ConditionOperator, "not more")
+	}
+}
+
+func TestRegisterConditionPreservesBrowserVersionValueType(t *testing.T) {
+	registry := NewRuleRegistry()
+	err := registry.RegisterCondition(string(dbgen.RuleConditionPropertyBrowserVersion), browserVersionConditionParser, "Custom display", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	registration, ok := registry.conditionRegistration(string(dbgen.RuleConditionPropertyBrowserVersion))
+	if !ok {
+		t.Fatal("browser version condition is not registered")
+	}
+	if registration.valueType != conditionValueInteger {
+		t.Errorf("valueType = %v, want %v", registration.valueType, conditionValueInteger)
 	}
 }
 
@@ -595,6 +661,40 @@ func TestParseCountryCodeConditionInvalidOperator(t *testing.T) {
 	}
 }
 
+func TestParseBrowserVersionCondition(t *testing.T) {
+	tests := []struct {
+		name           string
+		operator       string
+		value          string
+		expectedValue  string
+		expectedStatus common.StatusCode
+	}{
+		{name: "valid", operator: string(dbgen.RuleConditionOperatorMore), value: "3", expectedValue: "3", expectedStatus: common.StatusOK},
+		{name: "maximum int32", operator: string(dbgen.RuleConditionOperatorMore), value: "2147483647", expectedValue: "2147483647", expectedStatus: common.StatusOK},
+		{name: "invalid operator", operator: string(dbgen.RuleConditionOperatorEquals), value: "3", expectedStatus: common.StatusRuleConditionOperatorInvalid},
+		{name: "empty", operator: string(dbgen.RuleConditionOperatorMore), expectedStatus: common.StatusRuleConditionValueRequired},
+		{name: "non integer", operator: string(dbgen.RuleConditionOperatorMore), value: "1.5", expectedStatus: common.StatusRuleConditionValueInvalid},
+		{name: "zero", operator: string(dbgen.RuleConditionOperatorMore), value: "0", expectedStatus: common.StatusRuleConditionValueInvalid},
+		{name: "negative", operator: string(dbgen.RuleConditionOperatorMore), value: "-1", expectedStatus: common.StatusRuleConditionValueInvalid},
+		{name: "overflow", operator: string(dbgen.RuleConditionOperatorMore), value: "2147483648", expectedStatus: common.StatusRuleConditionValueInvalid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, separator, status := browserVersionConditionParser(tt.operator, tt.value, "")
+			if status != tt.expectedStatus {
+				t.Errorf("browserVersionConditionParser() status = %v, want %v", status, tt.expectedStatus)
+			}
+			if value != tt.expectedValue {
+				t.Errorf("browserVersionConditionParser() value = %q, want %q", value, tt.expectedValue)
+			}
+			if separator != "" {
+				t.Errorf("browserVersionConditionParser() separator = %q, want empty", separator)
+			}
+		})
+	}
+}
+
 func TestParseDifficultyAction(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -873,6 +973,67 @@ func TestCreateOrgRule(t *testing.T) {
 	}
 }
 
+func TestCreateBrowserVersionRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := t.Context()
+	user, org, err := db_tests.CreateNewAccountForTest(ctx, store, t.Name(), testPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := http.NewServeMux()
+	server.Setup(portalDomain(), common.NoopMiddleware).Register(srv)
+	cookie, err := portal_tests.AuthenticateSuite(ctx, user.Email, srv, server.XSRF, server.Sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := postCreateOrgRule(srv, cookie, user, org, "Outdated org browser",
+		string(dbgen.RuleConditionPropertyBrowserVersion), string(dbgen.RuleConditionOperatorMore)+"_negated", "4",
+		string(dbgen.RuleActionPropertyHTTPRequest), "block")
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("create org rule status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	orgRules, err := store.Impl().RetrieveDifficultyRulesByOrgIDs(ctx, map[int32]uint{org.ID: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(orgRules[org.ID]) != 1 {
+		t.Fatalf("org rule count = %d, want 1", len(orgRules[org.ID]))
+	}
+	orgRule := orgRules[org.ID][0]
+	assertBrowserVersionRule(t, orgRule, 4, true)
+
+	resp = postEditOrgRule(srv, cookie, user, org, orgRule, "Country rule",
+		string(dbgen.RuleConditionPropertyCountryCode), string(dbgen.RuleConditionOperatorIn), "DE,FR",
+		string(dbgen.RuleActionPropertyHTTPRequest), "block")
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("edit to string rule status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	orgRule, err = store.Impl().RetrieveDifficultyRule(ctx, orgRule.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if orgRule.ConditionValueInt.Valid || !orgRule.ConditionValueStr.Valid || !orgRule.ConditionValueSeparator.Valid {
+		t.Errorf("string condition values = int:%+v str:%+v separator:%+v", orgRule.ConditionValueInt, orgRule.ConditionValueStr, orgRule.ConditionValueSeparator)
+	}
+
+	resp = postEditOrgRule(srv, cookie, user, org, orgRule, "Outdated org browser",
+		string(dbgen.RuleConditionPropertyBrowserVersion), string(dbgen.RuleConditionOperatorMore)+"_negated", "5",
+		string(dbgen.RuleActionPropertyHTTPRequest), "block")
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("edit to integer rule status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	orgRule, err = store.Impl().RetrieveDifficultyRule(ctx, orgRule.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBrowserVersionRule(t, orgRule, 5, true)
+}
+
 func TestEditPropertyRule(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -925,6 +1086,25 @@ func TestEditPropertyRule(t *testing.T) {
 	if updatedRule.ActionValue != -30 {
 		t.Errorf("Unexpected action value: %d", updatedRule.ActionValue)
 	}
+
+	endpoint := fmt.Sprintf("/org/%s/property/%s/rules/%s/edit", server.IDHasher.Encrypt(int(org.ID)), server.IDHasher.Encrypt(int(prop.ID)), server.IDHasher.Encrypt(int(rule.ID)))
+	resp = postRuleRequest(srv, cookie, http.MethodPost, endpoint, server.XSRF.Token(strconv.Itoa(int(user.ID))), map[string]string{
+		common.ParamName:              "Outdated browser",
+		common.ParamEnabled:           "on",
+		common.ParamConditionProperty: string(dbgen.RuleConditionPropertyBrowserVersion),
+		common.ParamConditionOperator: string(dbgen.RuleConditionOperatorMore),
+		common.ParamConditionValue:    "4",
+		common.ParamActionProperty:    string(dbgen.RuleActionPropertyDifficultyLevelPercent),
+		common.ParamActionValue:       "50",
+	})
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("browser version edit status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	updatedRule, err = store.Impl().RetrieveDifficultyRule(ctx, rule.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBrowserVersionRule(t, updatedRule, 4, false)
 }
 
 func TestEditOrgRule(t *testing.T) {
@@ -3994,6 +4174,47 @@ func TestParseRuleFormNegativeCases(t *testing.T) {
 				t.Errorf("parseRuleForm() = %v, want %v", statusCode, tt.expectedCode)
 			}
 		})
+	}
+}
+
+func TestParseBrowserVersionRuleForm(t *testing.T) {
+	form := url.Values{
+		common.ParamName:              {"Outdated browser"},
+		common.ParamConditionProperty: {string(dbgen.RuleConditionPropertyBrowserVersion)},
+		common.ParamConditionOperator: {string(dbgen.RuleConditionOperatorMore)},
+		common.ParamConditionValue:    {"3"},
+		common.ParamActionProperty:    {string(dbgen.RuleActionPropertyDifficultyLevelPercent)},
+		common.ParamActionValue:       {"50"},
+	}
+	req := httptest.NewRequest("POST", "/test", strings.NewReader(form.Encode()))
+	req.Header.Set(common.HeaderContentType, common.ContentTypeURLEncoded)
+	if err := req.ParseForm(); err != nil {
+		t.Fatal(err)
+	}
+
+	params, status := (&Server{Rules: NewRuleRegistry()}).parseRuleForm(t.Context(), req, &RuleWizardRenderContext{}, "example.com")
+	if status != common.StatusOK {
+		t.Fatalf("parseRuleForm() = %v, want %v", status, common.StatusOK)
+	}
+	if !params.ConditionValueInt.Valid || params.ConditionValueInt.Int32 != 3 {
+		t.Errorf("ConditionValueInt = %+v, want valid 3", params.ConditionValueInt)
+	}
+	if params.ConditionValueStr.Valid {
+		t.Errorf("ConditionValueStr = %+v, want invalid", params.ConditionValueStr)
+	}
+	if params.ConditionValueSeparator.Valid {
+		t.Errorf("ConditionValueSeparator = %+v, want invalid", params.ConditionValueSeparator)
+	}
+}
+
+func TestBrowserVersionRuleToFormData(t *testing.T) {
+	form := ruleToFormData(&dbgen.DifficultyRule{
+		ConditionProperty: dbgen.RuleConditionPropertyBrowserVersion,
+		ConditionOperator: dbgen.RuleConditionOperatorMore,
+		ConditionValueInt: db.Int(7),
+	})
+	if form.ConditionValue != "7" {
+		t.Errorf("ConditionValue = %q, want %q", form.ConditionValue, "7")
 	}
 }
 

--- a/pkg/rules/browser_version_test.go
+++ b/pkg/rules/browser_version_test.go
@@ -1,0 +1,391 @@
+package rules
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+	"sync"
+	"testing"
+
+	dbgen "github.com/PrivateCaptcha/PrivateCaptcha/pkg/db/generated"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/medama-io/go-useragent"
+)
+
+type browserVersionCase struct {
+	name string
+	key  BrowserVersionKey
+	ua   string
+}
+
+func browserVersionCases(major int) []browserVersionCase {
+	return []browserVersionCase{
+		{
+			name: "ChromeWindows",
+			key:  BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformWindows},
+			ua:   fmt.Sprintf("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%d.0.0.0 Safari/537.36", major),
+		},
+		{
+			name: "ChromeMacOS",
+			key:  BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformMacOS},
+			ua:   fmt.Sprintf("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%d.0.0.0 Safari/537.36", major),
+		},
+		{
+			name: "ChromeLinux",
+			key:  BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformLinux},
+			ua:   fmt.Sprintf("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%d.0.0.0 Safari/537.36", major),
+		},
+		{
+			name: "FirefoxWindows",
+			key:  BrowserVersionKey{Browser: BrowserFirefox, Platform: PlatformWindows},
+			ua:   fmt.Sprintf("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:%d.0) Gecko/20100101 Firefox/%d.0", major, major),
+		},
+		{
+			name: "FirefoxMacOS",
+			key:  BrowserVersionKey{Browser: BrowserFirefox, Platform: PlatformMacOS},
+			ua:   fmt.Sprintf("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:%d.0) Gecko/20100101 Firefox/%d.0", major, major),
+		},
+		{
+			name: "FirefoxLinux",
+			key:  BrowserVersionKey{Browser: BrowserFirefox, Platform: PlatformLinux},
+			ua:   fmt.Sprintf("Mozilla/5.0 (X11; Linux x86_64; rv:%d.0) Gecko/20100101 Firefox/%d.0", major, major),
+		},
+		{
+			name: "ChromeAndroidWebView",
+			key:  BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformAndroid},
+			ua:   fmt.Sprintf("Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/UQ1A.240205.004; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/%d.0.0.0 Mobile Safari/537.36", major),
+		},
+		{
+			name: "ChromeIOS",
+			key:  BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformIOS},
+			ua:   fmt.Sprintf("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/%d.0.0.0 Mobile/15E148 Safari/604.1", major),
+		},
+		{
+			name: "FirefoxAndroid",
+			key:  BrowserVersionKey{Browser: BrowserFirefox, Platform: PlatformAndroid},
+			ua:   fmt.Sprintf("Mozilla/5.0 (Android 14; Mobile; rv:%d.0) Gecko/%d.0 Firefox/%d.0", major, major, major),
+		},
+		{
+			name: "ChromeAndroidTablet",
+			key:  BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformAndroid},
+			ua:   fmt.Sprintf("Mozilla/5.0 (Linux; Android 14; Pixel Tablet) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%d.0.0.0 Safari/537.36", major),
+		},
+	}
+}
+
+func newBrowserVersionRule(threshold int32) *dbgen.DifficultyRule {
+	return &dbgen.DifficultyRule{
+		ID:                42,
+		ConditionProperty: dbgen.RuleConditionPropertyBrowserVersion,
+		ConditionOperator: dbgen.RuleConditionOperatorMore,
+		ConditionValueInt: pgtype.Int4{Int32: threshold, Valid: true},
+		ActionProperty:    dbgen.RuleActionPropertyDifficultyLevelPercent,
+		ActionValue:       100,
+		Enabled:           true,
+	}
+}
+
+func browserVersionRequest(ua string) *RequestInfo {
+	return newTestRequestInfo(ua, netip.MustParseAddr("1.2.3.4"))
+}
+
+func TestBrowserVersionCompileValidation(t *testing.T) {
+	compiler := NewRulesCompiler(useragent.NewParser())
+	if _, err := compiler.CompileRule(t.Context(), newBrowserVersionRule(1)); err != nil {
+		t.Fatalf("valid rule failed to compile: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*dbgen.DifficultyRule)
+		wantErr error
+	}{
+		{
+			name: "MissingInteger",
+			mutate: func(rule *dbgen.DifficultyRule) {
+				rule.ConditionValueInt = pgtype.Int4{}
+			},
+			wantErr: ErrInvalidBrowserVersionRule,
+		},
+		{
+			name: "Zero",
+			mutate: func(rule *dbgen.DifficultyRule) {
+				rule.ConditionValueInt.Int32 = 0
+			},
+			wantErr: ErrInvalidBrowserVersionRule,
+		},
+		{
+			name: "IntegerAndString",
+			mutate: func(rule *dbgen.DifficultyRule) {
+				rule.ConditionValueStr = pgtype.Text{String: "2", Valid: true}
+			},
+			wantErr: ErrInvalidBrowserVersionRule,
+		},
+		{
+			name: "Separator",
+			mutate: func(rule *dbgen.DifficultyRule) {
+				rule.ConditionValueSeparator = pgtype.Text{String: ",", Valid: true}
+			},
+			wantErr: ErrInvalidBrowserVersionRule,
+		},
+		{
+			name: "WrongOperator",
+			mutate: func(rule *dbgen.DifficultyRule) {
+				rule.ConditionOperator = dbgen.RuleConditionOperatorEquals
+			},
+			wantErr: ErrUnsupportedConditionOperator,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := newBrowserVersionRule(2)
+			tt.mutate(rule)
+			_, err := compiler.CompileRule(t.Context(), rule)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("CompileRule error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBrowserVersionMatchesThresholdAndNegation(t *testing.T) {
+	compiler := NewRulesCompiler(useragent.NewParser())
+	compiler.BrowserVersions().Replace(map[BrowserVersionKey]int{
+		{Browser: BrowserChrome, Platform: PlatformWindows}: 152,
+	})
+	compiled, err := compiler.CompileRule(t.Context(), newBrowserVersionRule(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	negatedRule := newBrowserVersionRule(2)
+	negatedRule.ConditionOperatorNegated = true
+	negated, err := compiler.CompileRule(t.Context(), negatedRule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		major       int
+		want        bool
+		wantNegated bool
+	}{
+		{name: "MoreThanThreshold", major: 149, want: true, wantNegated: false},
+		{name: "EqualToThreshold", major: 150, want: false, wantNegated: true},
+		{name: "Newer", major: 153, want: false, wantNegated: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := browserVersionRequest(browserVersionCases(tt.major)[0].ua)
+			if got := compiled.Matches(request); got != tt.want {
+				t.Fatalf("Matches() = %v, want %v", got, tt.want)
+			}
+			if got := negated.Matches(request); got != tt.wantNegated {
+				t.Fatalf("negated Matches() = %v, want %v", got, tt.wantNegated)
+			}
+		})
+	}
+}
+
+func TestBrowserVersionMatchesSupportedBrowserPlatforms(t *testing.T) {
+	for _, tt := range browserVersionCases(149) {
+		t.Run(tt.name, func(t *testing.T) {
+			compiler := NewRulesCompiler(useragent.NewParser())
+			compiler.BrowserVersions().Replace(map[BrowserVersionKey]int{tt.key: 152})
+			compiled, err := compiler.CompileRule(t.Context(), newBrowserVersionRule(2))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !compiled.Matches(browserVersionRequest(tt.ua)) {
+				t.Fatal("supported browser and platform did not match")
+			}
+		})
+	}
+}
+
+func TestBrowserVersionCompiledMatcherObservesUpdates(t *testing.T) {
+	compiler := NewRulesCompiler(useragent.NewParser())
+	key := BrowserVersionKey{Browser: BrowserFirefox, Platform: PlatformLinux}
+	compiler.BrowserVersions().Replace(map[BrowserVersionKey]int{key: 152})
+	compiled, err := compiler.CompileRule(t.Context(), newBrowserVersionRule(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := browserVersionRequest(browserVersionCases(149)[5].ua)
+	if !compiled.Matches(request) {
+		t.Fatal("initial browser versions did not match")
+	}
+
+	compiler.BrowserVersions().Replace(map[BrowserVersionKey]int{key: 151})
+	if compiled.Matches(request) {
+		t.Fatal("compiled matcher did not observe a non-matching provider update")
+	}
+}
+
+func TestBrowserVersionFailsOpenForMalformedAndUnsupportedUserAgents(t *testing.T) {
+	compiler := NewRulesCompiler(useragent.NewParser())
+	compiler.BrowserVersions().Replace(browserVersionsSnapshot(152))
+	compiled, err := compiler.CompileRule(t.Context(), newBrowserVersionRule(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	negatedRule := newBrowserVersionRule(2)
+	negatedRule.ConditionOperatorNegated = true
+	negated, err := compiler.CompileRule(t.Context(), negatedRule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		ua   string
+	}{
+		{name: "Empty", ua: ""},
+		{name: "SafariMacOS", ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"},
+		{name: "EdgeWindows", ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36 Edg/149.0.0.0"},
+		{name: "FirefoxIOS", ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/149.0 Mobile/15E148 Safari/605.1.15"},
+		{name: "ChromeOS", ua: "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"},
+		{name: "MissingVersion", ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/ Safari/537.36"},
+		{name: "OverflowingVersion", ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/999999999999999999999.0 Safari/537.36"},
+		{name: "Oversized", ua: browserVersionCases(149)[0].ua + strings.Repeat("A", browserVersionMaxUserAgentBytes)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := browserVersionRequest(tt.ua)
+			if compiled.Matches(request) {
+				t.Fatal("malformed or unsupported user agent matched")
+			}
+			if negated.Matches(request) {
+				t.Fatal("malformed or unsupported user agent matched negated rule")
+			}
+		})
+	}
+}
+
+func TestBrowserVersionFailsOpenWithoutRuntimeDependencies(t *testing.T) {
+	parser := useragent.NewParser()
+	versions := NewBrowserVersions()
+	versions.Replace(map[BrowserVersionKey]int{
+		{Browser: BrowserChrome, Platform: PlatformWindows}: 152,
+	})
+	request := browserVersionRequest(browserVersionCases(149)[0].ua)
+	tests := []struct {
+		name    string
+		matcher *BrowserVersionMatcher
+		stale   bool
+	}{
+		{name: "NilParser", matcher: &BrowserVersionMatcher{BrowserVersions: versions, Threshold: 2}, stale: true},
+		{name: "NilVersions", matcher: &BrowserVersionMatcher{UAParser: parser, Threshold: 2}, stale: true},
+		{name: "EmptyVersions", matcher: &BrowserVersionMatcher{UAParser: parser, BrowserVersions: NewBrowserVersions(), Threshold: 2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.matcher.IsStale(); got != tt.stale {
+				t.Fatalf("IsStale() = %v, want %v", got, tt.stale)
+			}
+			if tt.matcher.Matches(request) {
+				t.Fatal("matcher without complete runtime data matched")
+			}
+		})
+	}
+	negated := &BrowserVersionMatcher{UAParser: parser, BrowserVersions: NewBrowserVersions(), Threshold: 2, ConditionOperatorNegated: true}
+	if negated.Matches(request) {
+		t.Fatal("negated matcher without a baseline matched")
+	}
+}
+
+func TestBrowserVersionGobPreservesNegation(t *testing.T) {
+	original := &BrowserVersionMatcher{Threshold: 2, ConditionOperatorNegated: true}
+	data, err := original.GobEncode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded BrowserVersionMatcher
+	if err := decoded.GobDecode(data); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Threshold != original.Threshold {
+		t.Errorf("Threshold = %d, want %d", decoded.Threshold, original.Threshold)
+	}
+	if !decoded.ConditionOperatorNegated {
+		t.Error("ConditionOperatorNegated = false, want true")
+	}
+	if !decoded.IsStale() {
+		t.Error("decoded matcher is not stale")
+	}
+	if decoded.Matches(browserVersionRequest(browserVersionCases(149)[0].ua)) {
+		t.Error("decoded stale negated matcher matched")
+	}
+}
+
+func browserVersionsSnapshot(major int) map[BrowserVersionKey]int {
+	return map[BrowserVersionKey]int{
+		{Browser: BrowserChrome, Platform: PlatformWindows}:  major,
+		{Browser: BrowserChrome, Platform: PlatformMacOS}:    major,
+		{Browser: BrowserChrome, Platform: PlatformLinux}:    major,
+		{Browser: BrowserChrome, Platform: PlatformAndroid}:  major,
+		{Browser: BrowserChrome, Platform: PlatformIOS}:      major,
+		{Browser: BrowserFirefox, Platform: PlatformWindows}: major,
+		{Browser: BrowserFirefox, Platform: PlatformMacOS}:   major,
+		{Browser: BrowserFirefox, Platform: PlatformLinux}:   major,
+		{Browser: BrowserFirefox, Platform: PlatformAndroid}: major,
+	}
+}
+
+func TestBrowserVersionsReplacesWholeSnapshot(t *testing.T) {
+	provider := NewBrowserVersions()
+	key := BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformWindows}
+	versions := browserVersionsSnapshot(152)
+	provider.Replace(versions)
+	versions[key] = 999
+
+	if major, ok := provider.Major(key); !ok || major != 152 {
+		t.Fatalf("Major() = %d, %v, want 152, true", major, ok)
+	}
+
+	provider.Replace(map[BrowserVersionKey]int{
+		{Browser: BrowserFirefox, Platform: PlatformLinux}: 153,
+	})
+	if _, ok := provider.Major(key); ok {
+		t.Fatal("replacement retained an entry from the previous snapshot")
+	}
+}
+
+func TestBrowserVersionsSupportsConcurrentReadsAndReplacements(t *testing.T) {
+	provider := NewBrowserVersions()
+	oldSnapshot := browserVersionsSnapshot(152)
+	newSnapshot := browserVersionsSnapshot(153)
+	provider.Replace(oldSnapshot)
+	key := BrowserVersionKey{Browser: BrowserChrome, Platform: PlatformWindows}
+
+	done := make(chan struct{})
+	var readers sync.WaitGroup
+	for range 8 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				major, ok := provider.Major(key)
+				if !ok || (major != 152 && major != 153) {
+					t.Errorf("concurrent Major() = %d, %v", major, ok)
+					return
+				}
+			}
+		}()
+	}
+
+	for range 10_000 {
+		provider.Replace(newSnapshot)
+		provider.Replace(oldSnapshot)
+	}
+	close(done)
+	readers.Wait()
+}

--- a/pkg/rules/browser_versions.go
+++ b/pkg/rules/browser_versions.go
@@ -1,0 +1,50 @@
+package rules
+
+import "sync"
+
+const (
+	BrowserChrome  = "chrome"
+	BrowserFirefox = "firefox"
+
+	PlatformWindows = "windows"
+	PlatformMacOS   = "macos"
+	PlatformLinux   = "linux"
+	PlatformAndroid = "android"
+	PlatformIOS     = "ios"
+)
+
+type BrowserVersionKey struct {
+	Browser  string
+	Platform string
+}
+
+type BrowserVersions struct {
+	mu       sync.RWMutex
+	versions map[BrowserVersionKey]int
+}
+
+func NewBrowserVersions() *BrowserVersions {
+	return &BrowserVersions{versions: make(map[BrowserVersionKey]int)}
+}
+
+func (p *BrowserVersions) Major(key BrowserVersionKey) (int, bool) {
+	if p == nil {
+		return 0, false
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	major, ok := p.versions[key]
+	return major, ok
+}
+
+func (p *BrowserVersions) Replace(versions map[BrowserVersionKey]int) {
+	replacement := make(map[BrowserVersionKey]int, len(versions))
+	for key, major := range versions {
+		replacement[key] = major
+	}
+
+	p.mu.Lock()
+	p.versions = replacement
+	p.mu.Unlock()
+}

--- a/pkg/rules/matchers.go
+++ b/pkg/rules/matchers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"net/netip"
+	"strconv"
 	"strings"
 
 	dbgen "github.com/PrivateCaptcha/PrivateCaptcha/pkg/db/generated"
@@ -236,6 +237,114 @@ func (bm *BotMatcher) Matches(ri *RequestInfo) bool {
 	result := bm.looksLikeBot(ri.UserAgent())
 
 	if bm.ConditionOperatorNegated {
+		return !result
+	}
+	return result
+}
+
+type BrowserVersionMatcher struct {
+	UAParser                 *useragent.Parser
+	BrowserVersions          *BrowserVersions
+	Threshold                int32
+	ConditionOperatorNegated bool
+}
+
+const browserVersionMaxUserAgentBytes = 4 * 1024
+
+var _ Matcher = (*BrowserVersionMatcher)(nil)
+
+func (m *BrowserVersionMatcher) GobEncode() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(m.Threshold); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(m.ConditionOperatorNegated); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (m *BrowserVersionMatcher) GobDecode(data []byte) error {
+	m.UAParser = nil
+	m.BrowserVersions = nil
+	dec := gob.NewDecoder(bytes.NewBuffer(data))
+	if err := dec.Decode(&m.Threshold); err != nil {
+		return err
+	}
+	return dec.Decode(&m.ConditionOperatorNegated)
+}
+
+func (m *BrowserVersionMatcher) IsStale() bool {
+	return m.UAParser == nil || m.BrowserVersions == nil
+}
+
+func browserVersionKey(ua useragent.UserAgent) (BrowserVersionKey, bool) {
+	var key BrowserVersionKey
+	switch ua.Browser() {
+	case agents.BrowserChrome:
+		key.Browser = BrowserChrome
+	case agents.BrowserFirefox:
+		key.Browser = BrowserFirefox
+	default:
+		return BrowserVersionKey{}, false
+	}
+	switch ua.OS() {
+	case agents.OSWindows:
+		if ua.Device() != agents.DeviceDesktop {
+			return BrowserVersionKey{}, false
+		}
+		key.Platform = PlatformWindows
+	case agents.OSMacOS:
+		if ua.Device() != agents.DeviceDesktop {
+			return BrowserVersionKey{}, false
+		}
+		key.Platform = PlatformMacOS
+	case agents.OSLinux:
+		if ua.Device() != agents.DeviceDesktop {
+			return BrowserVersionKey{}, false
+		}
+		key.Platform = PlatformLinux
+	case agents.OSAndroid:
+		if ua.Device() != agents.DeviceMobile && ua.Device() != agents.DeviceTablet {
+			return BrowserVersionKey{}, false
+		}
+		key.Platform = PlatformAndroid
+	case agents.OSIOS:
+		if key.Browser != BrowserChrome || (ua.Device() != agents.DeviceMobile && ua.Device() != agents.DeviceTablet) {
+			return BrowserVersionKey{}, false
+		}
+		key.Platform = PlatformIOS
+	default:
+		return BrowserVersionKey{}, false
+	}
+	return key, true
+}
+
+func (m *BrowserVersionMatcher) Matches(ri *RequestInfo) bool {
+	if ri == nil || m.IsStale() || m.Threshold <= 0 {
+		return false
+	}
+
+	rawUserAgent := ri.UserAgent()
+	if len(rawUserAgent) > browserVersionMaxUserAgentBytes {
+		return false
+	}
+	ua := m.UAParser.Parse(rawUserAgent)
+	key, ok := browserVersionKey(ua)
+	if !ok {
+		return false
+	}
+	requestMajor, err := strconv.Atoi(ua.BrowserVersionMajor())
+	if err != nil || requestMajor <= 0 {
+		return false
+	}
+	currentMajor, ok := m.BrowserVersions.Major(key)
+	if !ok || currentMajor <= 0 {
+		return false
+	}
+	result := currentMajor > requestMajor && currentMajor-requestMajor > int(m.Threshold)
+	if m.ConditionOperatorNegated {
 		return !result
 	}
 	return result

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -24,6 +24,7 @@ var (
 	ErrIPEqualsMultipleValues       = errors.New("equals operator requires exactly one IP address value")
 	ErrIPNonSingletonPrefix         = errors.New("equals/in operator requires single IP addresses, not CIDR ranges")
 	ErrUnsupportedConditionOperator = errors.New("unsupported condition operator for rule")
+	ErrInvalidBrowserVersionRule    = errors.New("invalid browser version rule")
 )
 
 const (
@@ -380,6 +381,7 @@ func init() {
 	gob.Register(&IPMatcher{})
 	gob.Register(&HeaderMatcher{})
 	gob.Register(&BotMatcher{})
+	gob.Register(&BrowserVersionMatcher{})
 	gob.Register(&AlwaysMatcher{})
 }
 
@@ -480,19 +482,25 @@ func buildAlwaysMatcher(_ *dbgen.DifficultyRule) (Matcher, error) {
 
 // RulesCompiler compiles database rules into executable rule objects.
 type RulesCompiler struct {
-	uaParser  *useragent.Parser
-	factories map[string]MatcherFactory
+	uaParser        *useragent.Parser
+	factories       map[string]MatcherFactory
+	browserVersions *BrowserVersions
 }
 
 // NewRulesCompiler creates a new RulesCompiler with the provided user agent parser.
 // The uaParser must not be nil; it is required for compiling user-agent based rules.
 func NewRulesCompiler(uaParser *useragent.Parser) *RulesCompiler {
 	rc := &RulesCompiler{
-		uaParser:  uaParser,
-		factories: make(map[string]MatcherFactory),
+		uaParser:        uaParser,
+		factories:       make(map[string]MatcherFactory),
+		browserVersions: NewBrowserVersions(),
 	}
 	rc.registerDefaultFactories()
 	return rc
+}
+
+func (rc *RulesCompiler) BrowserVersions() *BrowserVersions {
+	return rc.browserVersions
 }
 
 func (rc *RulesCompiler) registerDefaultFactories() {
@@ -502,6 +510,7 @@ func (rc *RulesCompiler) registerDefaultFactories() {
 	rc.factories[string(dbgen.RuleConditionPropertyIPAddress)] = BuildIPMatcher
 	rc.factories[string(dbgen.RuleConditionPropertyHTTPHeaderName)] = BuildHeaderMatcher
 	rc.factories[string(dbgen.RuleConditionPropertyAlways)] = buildAlwaysMatcher
+	rc.factories[string(dbgen.RuleConditionPropertyBrowserVersion)] = rc.buildBrowserVersionMatcher
 }
 
 // RegisterMatcherFactory registers a MatcherFactory for the given condition property,
@@ -522,6 +531,22 @@ func (rc *RulesCompiler) buildUserAgentMatcher(rule *dbgen.DifficultyRule) (Matc
 		}, nil
 	}
 	return BuildStringMatcher(rule)
+}
+
+func (rc *RulesCompiler) buildBrowserVersionMatcher(rule *dbgen.DifficultyRule) (Matcher, error) {
+	if rule.ConditionOperator != dbgen.RuleConditionOperatorMore {
+		return nil, ErrUnsupportedConditionOperator
+	}
+	if !rule.ConditionValueInt.Valid || rule.ConditionValueInt.Int32 <= 0 ||
+		rule.ConditionValueStr.Valid || rule.ConditionValueSeparator.Valid {
+		return nil, ErrInvalidBrowserVersionRule
+	}
+	return &BrowserVersionMatcher{
+		UAParser:                 rc.uaParser,
+		BrowserVersions:          rc.browserVersions,
+		Threshold:                rule.ConditionValueInt.Int32,
+		ConditionOperatorNegated: rule.ConditionOperatorNegated,
+	}, nil
 }
 
 var _ Compiler = (*RulesCompiler)(nil)

--- a/web/layouts/rules/form.html
+++ b/web/layouts/rules/form.html
@@ -40,6 +40,7 @@
             <div class="mt-2">
                 <select name="{{ .Const.ConditionProperty }}" id="{{ .Const.ConditionProperty }}" x-model="conditionProperty" class="w-full pc-internal-form-select">
                     {{ with .Const.ConditionPropertyUserAgent }}<option value="{{ . }}" {{ if eq $.Params.ConditionProperty . }}selected{{ end }}>User Agent</option>{{ end }}
+                    {{ with .Const.ConditionPropertyBrowserVersion }}<option value="{{ . }}" {{ if eq $.Params.ConditionProperty . }}selected{{ end }}>Browser version</option>{{ end }}
                     {{ with .Const.ConditionPropertyIPAddress }}<option value="{{ . }}" {{ if eq $.Params.ConditionProperty . }}selected{{ end }}>IP Address</option>{{ end }}
                     {{ with .Const.ConditionPropertyCountryCode }}<option value="{{ . }}" {{ if eq $.Params.ConditionProperty . }}selected{{ end }}>Country</option>{{ end }}
                     {{ if and .Params.Property .Params.Property.HasDomain }}{{ with .Const.ConditionPropertyDomain }}<option value="{{ . }}" {{ if eq $.Params.ConditionProperty . }}selected{{ end }}>Domain</option>{{ end }}{{ end }}
@@ -66,6 +67,14 @@
             <div class="mt-2">
                 <input id="userAgentInput" type="text" x-model="conditionValueUserAgent" placeholder="Enter user agent..." class="w-full pc-internal-form-input-base pc-form-input-normal" />
             </div>
+        </div>
+
+        <div x-cloak x-show="conditionProperty === '{{ .Const.ConditionPropertyBrowserVersion }}' && showConditionValue">
+            <label for="browserVersionInput" class="pc-internal-form-label">Major versions behind</label>
+            <div class="mt-2">
+                <input id="browserVersionInput" type="number" min="1" step="1" x-model="conditionValueBrowserVersion" aria-describedby="browserVersionInput-description" class="w-full pc-internal-form-input-base pc-form-input-normal" />
+            </div>
+            <p id="browserVersionInput-description" class="mt-1 text-xs text-pc-grey-800">Matches Chrome or Firefox versions <span x-text="conditionOperator === '{{ .Const.OperatorMore }}_negated' ? 'no more than' : 'more than'">more than</span> <span x-text="conditionValueBrowserVersion || 'this many'">this many</span> <span x-text="Number(conditionValueBrowserVersion) === 1 ? 'major version' : 'major versions'">major versions</span> behind the latest release.</p>
         </div>
 
         <div x-cloak x-show="conditionProperty === '{{ .Const.ConditionPropertyDomain }}' && showConditionValue">

--- a/web/layouts/rules/scripts.html
+++ b/web/layouts/rules/scripts.html
@@ -40,6 +40,17 @@ function ruleFormData() {
                 { value: '{{ .Const.OperatorBot }}_negated', label: 'Is Not Known Bot' }
             ]
         },
+        '{{ .Const.ConditionPropertyBrowserVersion }}': {
+            stateField: 'conditionValueBrowserVersion',
+            emptyValue: '',
+            initialValue: formDataConditionProperty === '{{ .Const.ConditionPropertyBrowserVersion }}' ? formDataConditionValue : '',
+            getFormattedValue: (ctx) => ctx.conditionValueBrowserVersion,
+            showOperator: true,
+            operators: [
+                { value: '{{ .Const.OperatorMore }}', label: 'More' },
+                { value: '{{ .Const.OperatorMore }}_negated', label: 'Less or equal' }
+            ]
+        },
         '{{ .Const.ConditionPropertyIPAddress }}': {
             stateField: 'conditionValueIPAddress',
             emptyValue: '',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-version rule conditions for Chrome and Firefox across supported platforms.
  * Configure how many major versions behind the latest release should match.
  * Added support for negated browser-version comparisons.
  * Browser-version data is automatically fetched, validated, cached, and refreshed.
* **Bug Fixes**
  * Improved handling of invalid browser-version values and unsupported browser data.
  * Added clearer status reporting when a rule condition value is invalid.
* **Tests**
  * Added comprehensive coverage for rule creation, editing, matching, and version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->