### PR TITLE
Fix clearing registration verification cache

### DIFF
--- a/pkg/db/generated/sessions.sql.go
+++ b/pkg/db/generated/sessions.sql.go
@@ -786,7 +786,8 @@ func (q *Queries) RevokeUserSessions(ctx context.Context, userID pgtype.Int4) ([
 
 const setVerifyRegistration = `-- name: SetVerifyRegistration :one
 UPDATE backend.sessions AS sessions
-SET verify_registration = $1
+SET verify_registration = $1,
+    version = sessions.version + 1
 WHERE session_id = $2
   AND state = 'pending'
   AND challenge_kind = 'registration'

--- a/pkg/db/queries/postgres/sessions.sql
+++ b/pkg/db/queries/postgres/sessions.sql
@@ -93,7 +93,8 @@ RETURNING sessions.*;
 
 -- name: SetVerifyRegistration :one
 UPDATE backend.sessions AS sessions
-SET verify_registration = @value
+SET verify_registration = @value,
+    version = sessions.version + 1
 WHERE session_id = @session_id
   AND state = 'pending'
   AND challenge_kind = 'registration'

--- a/pkg/db/session.go
+++ b/pkg/db/session.go
@@ -192,7 +192,7 @@ func (ss *SessionStore) SetVerifyRegistration(ctx context.Context, sid string, v
 	// Payload persistence may have advanced the cache version while preserving the committed screening mark.
 	ss.sessionCache.ComputeIfPresent(sid, func(current *session.Session) (*session.Session, otter.ComputeOp) {
 		authority, ok := current.Authority()
-		if !ok || authority.State != session.StatePending || authority.ChallengeKind != session.ChallengeKindRegistration {
+		if !ok || authority.Version > stored.Version || authority.State != session.StatePending || authority.ChallengeKind != session.ChallengeKindRegistration {
 			return current, otter.CancelOp
 		}
 		authority.VerifyRegistration = value

--- a/pkg/db/session.go
+++ b/pkg/db/session.go
@@ -192,7 +192,7 @@ func (ss *SessionStore) SetVerifyRegistration(ctx context.Context, sid string, v
 	// Payload persistence may have advanced the cache version while preserving the committed screening mark.
 	ss.sessionCache.ComputeIfPresent(sid, func(current *session.Session) (*session.Session, otter.ComputeOp) {
 		authority, ok := current.Authority()
-		if !ok || authority.State != session.StatePending || authority.ChallengeKind != session.ChallengeKindRegistration || authority.VerifyRegistration {
+		if !ok || authority.State != session.StatePending || authority.ChallengeKind != session.ChallengeKindRegistration {
 			return current, otter.CancelOp
 		}
 		authority.VerifyRegistration = value

--- a/pkg/db/session_cache_test.go
+++ b/pkg/db/session_cache_test.go
@@ -440,6 +440,40 @@ func TestSessionStoreSetsRegistrationVerificationInCachedAuthority(t *testing.T)
 	}
 }
 
+func TestSessionStoreClearsRegistrationVerificationInCachedAuthority(t *testing.T) {
+	sid := t.Name()
+	payload := session.NewPayload(sid, noopPayloadStore{})
+	data, err := payload.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored := &dbgen.Session{
+		SessionID: sid, State: dbgen.SessionStatePending, Version: 1, Data: data,
+		ExpiresAt: Timestampz(time.Now().Add(time.Hour)),
+		ChallengeKind: dbgen.NullSessionChallengeKind{SessionChallengeKind: dbgen.SessionChallengeKindRegistration, Valid: true},
+		ChallengeEmail: Text("registrant@example.com"), VerifyRegistration: Bool(true),
+	}
+	querier := &registrationVerificationQuerier{QuerierStub: &QuerierStub{}, row: stored}
+	business := NewBusinessWithQuerier(nil, querier, NewStaticCache[CacheKey, any](100, &CacheMissingValue{}))
+	store := NewSessionStore(business, &sessionMetricsStub{})
+	if _, _, err := store.publishTransitionSession(storedDBSession(stored)); err != nil {
+		t.Fatal(err)
+	}
+
+	querier.row.VerifyRegistration = Bool(false)
+	if err := store.SetVerifyRegistration(t.Context(), sid, false); err != nil {
+		t.Fatal(err)
+	}
+	updated, ok := store.sessionCache.GetIfPresent(sid)
+	if !ok {
+		t.Fatal("updated registration session is absent from cache")
+	}
+	authority, ok := updated.Authority()
+	if !ok || authority.VerifyRegistration {
+		t.Fatalf("updated Authority = %+v, want registration verification cleared", authority)
+	}
+}
+
 func TestSessionStoreSetsRegistrationVerificationOnNewerCachedAuthority(t *testing.T) {
 	sid := t.Name()
 	payload := session.NewPayload(sid, noopPayloadStore{})

--- a/pkg/db/session_cache_test.go
+++ b/pkg/db/session_cache_test.go
@@ -474,7 +474,7 @@ func TestSessionStoreClearsRegistrationVerificationInCachedAuthority(t *testing.
 	}
 }
 
-func TestSessionStoreSetsRegistrationVerificationOnNewerCachedAuthority(t *testing.T) {
+func TestSessionStoreKeepsNewerCachedRegistrationVerification(t *testing.T) {
 	sid := t.Name()
 	payload := session.NewPayload(sid, noopPayloadStore{})
 	data, err := payload.Snapshot()
@@ -509,8 +509,8 @@ func TestSessionStoreSetsRegistrationVerificationOnNewerCachedAuthority(t *testi
 		t.Fatal("updated registration session is absent from cache")
 	}
 	authority, ok := updated.Authority()
-	if !ok || authority.Version != newer.Version || !authority.VerifyRegistration {
-		t.Fatalf("updated Authority = %+v, want marked version %d", authority, newer.Version)
+	if !ok || authority.Version != newer.Version || authority.VerifyRegistration {
+		t.Fatalf("updated Authority = %+v, want unmarked version %d", authority, newer.Version)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- The setter for `verify_registration` allowed writing `false` but did not advance the session `version`, and the same-version cache-merge logic unconditionally preserved an existing `true` value, leaving the process-local cache stale.

### Description

- Increment the session `version` when `verify_registration` is updated in SQL by changing `SET verify_registration = @value` to also `SET version = sessions.version + 1` in `pkg/db/queries/postgres/sessions.sql`.
- Keep the checked-in generated SQL in `pkg/db/generated/sessions.sql.go` synchronized with the source SQL to reflect the added `version` increment.
- Allow the post-persistence cache update in `pkg/db/session.go` to apply both `true` and `false` values by removing the earlier short-circuit that cancelled when the cached authority already had `VerifyRegistration == true` for pending registration sessions.
- Add a regression test `TestSessionStoreClearsRegistrationVerificationInCachedAuthority` in `pkg/db/session_cache_test.go` that verifies `SetVerifyRegistration(..., false)` clears an already-cached `true` authority.

### Testing

- Ran `make init` to build frontend assets and prepare the repo, which completed successfully.
- Ran `make test-unit` and observed unit test packages run through; DB package unit tests passed locally after `make init` asset setup.
- Ran `git diff --check` to ensure no whitespace or diff issues.
- Notes on environment limitations: `make sqlc` could not be executed because the `sqlc` binary was not available in the environment, so the generated query file was updated to match the source SQL manually; `make test-local` could not provision a PostgreSQL instance because `psql` was not available, so integration DB provisioning was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2b27a5938832a82336e1c4e49a72a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Session registration verification changes now update session versions consistently.
  - Cached session authority now preserves newer verification state when processing stale updates.
  - Clearing registration verification is correctly reflected in cached sessions, preventing outdated verification prompts or access behavior.

- **Tests**
  - Added coverage for clearing registration verification in cached sessions.
  - Added validation that newer cached verification state is preserved when older updates arrive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->